### PR TITLE
Fix local upload playback and configurable upload limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ HF_TOKEN=
 # ============================================================================
 # 3) HTTP Diagnostics & Slow Request Logging (optional)
 # ============================================================================
+# Max size for local uploaded media/subtitle files in bytes
+# Default: 2147483648 (2 GiB)
+# APP_UPLOAD_MAX_BYTES=2147483648
+
 # Log timing for all HTTP requests (1=on, 0=off)
 # APP_LOG_ALL_HTTP_TIMING=0
 

--- a/server/http/routes/project_routes.ts
+++ b/server/http/routes/project_routes.ts
@@ -16,6 +16,13 @@ const UPLOAD_VIDEO_EXTENSIONS = new Set([
   '.m4v',
   '.flv',
   '.ts',
+  '.mpeg',
+  '.mpg',
+  '.m2ts',
+  '.mts',
+  '.3gp',
+  '.ogv',
+  '.vob',
 ]);
 
 function getProjectManager() {
@@ -162,7 +169,8 @@ export function registerProjectRoutes(app: express.Express, handlers: ProjectRou
       }
 
       const VideoService = await getVideoService();
-      const audioPath = await VideoService.extractAudio(file.path, project.id);
+      const playbackVideoPath = await VideoService.ensureBrowserPlayableVideo(file.path, project.id);
+      const audioPath = await VideoService.extractAudio(playbackVideoPath, project.id);
       const inferredTitle = path.parse(String(file.originalname || file.filename || project.name || 'uploaded_video')).name.trim();
 
       return res.json({
@@ -172,7 +180,7 @@ export function registerProjectRoutes(app: express.Express, handlers: ProjectRou
           originalname: file.originalname,
           size: file.size,
         },
-        videoPath: PathManager.toClientPath(file.path),
+        videoPath: PathManager.toClientPath(playbackVideoPath),
         audioPath: PathManager.toClientPath(audioPath),
         videoTitle: inferredTitle || project.name || 'uploaded_video',
         sourceMode: 'upload',

--- a/server/http/upload.ts
+++ b/server/http/upload.ts
@@ -3,7 +3,23 @@ import multer from 'multer';
 import path from 'path';
 import { PathManager } from '../path_manager.js';
 
-const MAX_UPLOAD_BYTES = 2 * 1024 * 1024 * 1024;
+const DEFAULT_MAX_UPLOAD_BYTES = 2 * 1024 * 1024 * 1024;
+const UPLOAD_VIDEO_EXTENSIONS = new Set([
+  '.mp4', '.mkv', '.mov', '.avi', '.wmv', '.webm', '.m4v', '.flv', '.ts',
+  '.mpeg', '.mpg', '.m2ts', '.mts', '.3gp', '.ogv', '.vob',
+]);
+
+function getConfiguredMaxUploadBytes() {
+  const raw = String(process.env.APP_UPLOAD_MAX_BYTES || '').trim();
+  if (!raw) return DEFAULT_MAX_UPLOAD_BYTES;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_MAX_UPLOAD_BYTES;
+  }
+
+  return parsed;
+}
 
 function sanitizeUploadFilename(originalName: string) {
   const utf8Name = Buffer.from(originalName, 'latin1').toString('utf8');
@@ -21,6 +37,8 @@ function sanitizeUploadFilename(originalName: string) {
 }
 
 export function createUploadHandlers() {
+  const maxUploadBytes = getConfiguredMaxUploadBytes();
+
   const uploadStorage = multer.diskStorage({
     destination: (req, file, cb) => {
       try {
@@ -46,13 +64,13 @@ export function createUploadHandlers() {
   const upload = multer({
     storage: uploadStorage,
     limits: {
-      fileSize: MAX_UPLOAD_BYTES,
+      fileSize: maxUploadBytes,
       files: 1,
     },
     fileFilter: (req, file, cb) => {
       const ext = path.extname(file.originalname).toLowerCase();
       const allowed = [
-        '.mp4', '.mkv', '.mov', '.avi', '.wmv', '.webm', '.m4v', '.flv', '.ts',
+        ...UPLOAD_VIDEO_EXTENSIONS,
         '.mp3', '.wav', '.aac', '.m4a', '.flac',
         '.srt', '.vtt', '.ass', '.ssa',
       ];

--- a/server/services/video_service.ts
+++ b/server/services/video_service.ts
@@ -33,6 +33,17 @@ import type {
 
 export type { DownloadProgress } from '../video_sites/types.js';
 
+const DIRECT_MP4_VIDEO_CODECS = new Set(['h264', 'av1']);
+const DIRECT_MP4_AUDIO_CODECS = new Set(['aac', 'mp3']);
+const DIRECT_WEBM_VIDEO_CODECS = new Set(['vp8', 'vp9', 'av1']);
+const DIRECT_WEBM_AUDIO_CODECS = new Set(['opus', 'vorbis']);
+
+type BrowserPlaybackProbe = {
+  formatName: string;
+  videoCodec: string;
+  audioCodec: string;
+};
+
 function attachMetadataDebug(
   metadata: VideoMetadataResult,
   siteRuleId: string | null,
@@ -265,5 +276,137 @@ export class VideoService {
         resolve(audioPath);
       });
     });
+  }
+
+  private static async inspectBrowserPlaybackCompatibility(videoPath: string): Promise<BrowserPlaybackProbe> {
+    await this.ensureVideoToolsReady();
+    const { ffmpeg } = getVideoTools();
+
+    return new Promise((resolve, reject) => {
+      const proc = spawn(ffmpeg, ['-hide_banner', '-i', videoPath]);
+      let stderr = '';
+
+      proc.stderr.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      proc.on('close', () => {
+        const formatMatch = stderr.match(/Input #0,\s*([^,]+(?:,[^,]+)*)\s*,\s*from\b/i);
+        const videoCodecMatch = stderr.match(/Stream #\d+:\d+(?:\[[^\]]+\])?(?:\([^)]+\))?: Video:\s*([^,\s]+)/i);
+        const audioCodecMatch = stderr.match(/Stream #\d+:\d+(?:\[[^\]]+\])?(?:\([^)]+\))?: Audio:\s*([^,\s]+)/i);
+
+        const formatName = String(formatMatch?.[1] || '').trim().toLowerCase();
+        const videoCodec = String(videoCodecMatch?.[1] || '').trim().toLowerCase();
+        const audioCodec = String(audioCodecMatch?.[1] || '').trim().toLowerCase();
+
+        if (!formatName || !videoCodec) {
+          reject(new Error(`Unable to inspect media format for ${path.basename(videoPath)}`));
+          return;
+        }
+
+        resolve({ formatName, videoCodec, audioCodec });
+      });
+    });
+  }
+
+  private static isDirectBrowserPlayable(probe: BrowserPlaybackProbe) {
+    const format = probe.formatName;
+    const videoCodec = probe.videoCodec;
+    const audioCodec = probe.audioCodec;
+
+    const isMp4Family = /(mov|mp4|m4a|3gp|3g2|mj2)/i.test(format);
+    if (isMp4Family) {
+      const videoOk = DIRECT_MP4_VIDEO_CODECS.has(videoCodec);
+      const audioOk = !audioCodec || DIRECT_MP4_AUDIO_CODECS.has(audioCodec);
+      return videoOk && audioOk;
+    }
+
+    const isWebm = /\bwebm\b/i.test(format);
+    if (isWebm) {
+      const videoOk = DIRECT_WEBM_VIDEO_CODECS.has(videoCodec);
+      const audioOk = !audioCodec || DIRECT_WEBM_AUDIO_CODECS.has(audioCodec);
+      return videoOk && audioOk;
+    }
+
+    return false;
+  }
+
+  private static shouldAttemptMp4Remux(probe: BrowserPlaybackProbe) {
+    const videoCodec = probe.videoCodec;
+    const audioCodec = probe.audioCodec;
+    const videoOk = DIRECT_MP4_VIDEO_CODECS.has(videoCodec);
+    const audioOk = !audioCodec || DIRECT_MP4_AUDIO_CODECS.has(audioCodec);
+    return videoOk && audioOk;
+  }
+
+  static async ensureBrowserPlayableVideo(videoPath: string, projectId: string): Promise<string> {
+    await this.ensureVideoToolsReady();
+    const { ffmpeg } = getVideoTools();
+    const assetsDir = path.join(PathManager.getProjectPath(projectId), 'assets');
+    const outputPath = path.join(assetsDir, 'source.mp4');
+
+    await fs.ensureDir(assetsDir);
+
+    const probe = await this.inspectBrowserPlaybackCompatibility(videoPath);
+    if (this.isDirectBrowserPlayable(probe)) {
+      return videoPath;
+    }
+
+    const runFfmpeg = (args: string[]) =>
+      new Promise<void>((resolve, reject) => {
+        const proc = spawn(ffmpeg, args);
+        let stderr = '';
+
+        proc.stderr.on('data', (data) => {
+          stderr += data.toString();
+        });
+
+        proc.on('close', (code) => {
+          if (code === 0) {
+            resolve();
+            return;
+          }
+          reject(new Error(stderr.trim() || `ffmpeg exited with code ${code}`));
+        });
+      });
+
+    const remuxArgs = [
+      '-hide_banner',
+      '-i', videoPath,
+      '-map', '0:v:0',
+      '-map', '0:a?',
+      '-c', 'copy',
+      '-movflags', '+faststart',
+      '-y',
+      outputPath,
+    ];
+
+    if (this.shouldAttemptMp4Remux(probe)) {
+      try {
+        await runFfmpeg(remuxArgs);
+        return outputPath;
+      } catch (remuxError) {
+        console.warn(`[VideoService] MP4 remux failed for ${path.basename(videoPath)}. Falling back to transcode.`, remuxError);
+      }
+    }
+
+    const transcodeArgs = [
+      '-hide_banner',
+      '-i', videoPath,
+      '-map', '0:v:0',
+      '-map', '0:a?',
+      '-c:v', 'libx264',
+      '-preset', 'veryfast',
+      '-crf', '23',
+      '-pix_fmt', 'yuv420p',
+      '-c:a', 'aac',
+      '-b:a', '192k',
+      '-movflags', '+faststart',
+      '-y',
+      outputPath,
+    ];
+
+    await runFfmpeg(transcodeArgs);
+    return outputPath;
   }
 }

--- a/server/services/video_service.ts
+++ b/server/services/video_service.ts
@@ -344,6 +344,9 @@ export class VideoService {
     const { ffmpeg } = getVideoTools();
     const assetsDir = path.join(PathManager.getProjectPath(projectId), 'assets');
     const outputPath = path.join(assetsDir, 'source.mp4');
+    const tempOutputPath = path.join(assetsDir, `source.${Date.now()}.tmp.mp4`);
+    const normalizedOutputPath = path.resolve(outputPath);
+    const normalizedInputPath = path.resolve(videoPath);
 
     await fs.ensureDir(assetsDir);
 
@@ -351,6 +354,10 @@ export class VideoService {
     if (this.isDirectBrowserPlayable(probe)) {
       return videoPath;
     }
+
+    const ffmpegOutputPath = normalizedInputPath === normalizedOutputPath
+      ? tempOutputPath
+      : outputPath;
 
     const runFfmpeg = (args: string[]) =>
       new Promise<void>((resolve, reject) => {
@@ -378,7 +385,7 @@ export class VideoService {
       '-c', 'copy',
       '-movflags', '+faststart',
       '-y',
-      outputPath,
+      ffmpegOutputPath,
     ];
 
     if (this.shouldAttemptMp4Remux(probe)) {
@@ -403,10 +410,15 @@ export class VideoService {
       '-b:a', '192k',
       '-movflags', '+faststart',
       '-y',
-      outputPath,
+      ffmpegOutputPath,
     ];
 
     await runFfmpeg(transcodeArgs);
+
+    if (ffmpegOutputPath !== outputPath) {
+      await fs.move(ffmpegOutputPath, outputPath, { overwrite: true });
+    }
+
     return outputPath;
   }
 }

--- a/src/components/VideoDownloader.tsx
+++ b/src/components/VideoDownloader.tsx
@@ -14,7 +14,7 @@ interface VideoDownloaderProps {
   onNext: () => void;
 }
 
-const VIDEO_UPLOAD_EXTENSIONS = new Set(['mp4', 'mkv', 'mov', 'avi', 'wmv', 'webm', 'm4v', 'flv', 'ts']);
+const VIDEO_UPLOAD_EXTENSIONS = new Set(['mp4', 'mkv', 'mov', 'avi', 'wmv', 'webm', 'm4v', 'flv', 'ts', 'mpeg', 'mpg', 'm2ts', 'mts', '3gp', 'ogv', 'vob']);
 const VIDEO_UPLOAD_ACCEPT = '.mp4,.mkv,.mov,.avi,.wmv,.webm,.m4v,.flv,.ts';
 
 function getSourceModeCopy(language: Language) {
@@ -48,7 +48,7 @@ function getSourceModeCopy(language: Language) {
       msgUploading: '正在上傳影片並建立標準音檔...',
       msgReady: '影片與標準音檔已就緒。',
       errModeLockedOnline: '此專案已鎖定線上來源，無法使用本地上傳。',
-      errUnsupportedFormat: '僅支援上傳：mp4, mkv, mov, avi, wmv, webm, m4v, flv, ts。',
+      errUnsupportedFormat: '僅支援上傳：mp4, mkv, mov, avi, wmv, webm, m4v, flv, ts, mpeg, mpg, m2ts, mts, 3gp, ogv, vob。',
       errUploadFailed: '影片上傳失敗。',
       errParseDisabled: '目前是本地上傳模式，無法解析線上網址。',
       errDownloadDisabled: '此專案已鎖定本地上傳模式，無法進行線上下載。',
@@ -82,7 +82,7 @@ function getSourceModeCopy(language: Language) {
       msgUploading: '正在上传视频并生成标准音频...',
       msgReady: '视频与标准音频已就绪。',
       errModeLockedOnline: '此项目已锁定线上来源，无法使用本地上传。',
-      errUnsupportedFormat: '仅支持上传：mp4, mkv, mov, avi, wmv, webm, m4v, flv, ts。',
+      errUnsupportedFormat: '仅支持上传：mp4, mkv, mov, avi, wmv, webm, m4v, flv, ts, mpeg, mpg, m2ts, mts, 3gp, ogv, vob。',
       errUploadFailed: '视频上传失败。',
       errParseDisabled: '当前为本地上传模式，无法解析线上网址。',
       errDownloadDisabled: '此项目已锁定本地上传模式，无法进行线上下载。',
@@ -116,7 +116,7 @@ function getSourceModeCopy(language: Language) {
       msgUploading: 'Uploading video and creating standardized audio...',
       msgReady: 'Video and standardized audio are ready.',
       errModeLockedOnline: 'This project is locked to online source mode. Local upload is disabled.',
-      errUnsupportedFormat: 'Supported upload formats: mp4, mkv, mov, avi, wmv, webm, m4v, flv, ts.',
+      errUnsupportedFormat: 'Supported upload formats: mp4, mkv, mov, avi, wmv, webm, m4v, flv, ts, mpeg, mpg, m2ts, mts, 3gp, ogv, vob.',
       errUploadFailed: 'Video upload failed.',
       errParseDisabled: 'Local upload mode is active. Online URL parsing is disabled.',
       errDownloadDisabled: 'This project is locked to local upload mode. Online download is disabled.',
@@ -150,7 +150,7 @@ function getSourceModeCopy(language: Language) {
       msgUploading: '動画をアップロードし、標準音声を生成しています...',
       msgReady: '動画と標準音声の準備が完了しました。',
       errModeLockedOnline: 'このプロジェクトはオンラインソースに固定されているため、ローカルアップロードは無効です。',
-      errUnsupportedFormat: 'アップロード対応形式: mp4, mkv, mov, avi, wmv, webm, m4v, flv, ts。',
+      errUnsupportedFormat: 'アップロード対応形式: mp4, mkv, mov, avi, wmv, webm, m4v, flv, ts, mpeg, mpg, m2ts, mts, 3gp, ogv, vob。',
       errUploadFailed: '動画アップロードに失敗しました。',
       errParseDisabled: '現在はローカルアップロードモードのため、オンラインURL解析は無効です。',
       errDownloadDisabled: 'このプロジェクトはローカルアップロードモードに固定されているため、オンラインダウンロードは無効です。',
@@ -184,7 +184,7 @@ function getSourceModeCopy(language: Language) {
       msgUploading: 'Video wird hochgeladen und standardisiertes Audio wird erzeugt...',
       msgReady: 'Video und standardisiertes Audio sind bereit.',
       errModeLockedOnline: 'Dieses Projekt ist auf Online-Quelle gesperrt. Lokaler Upload ist deaktiviert.',
-      errUnsupportedFormat: 'Unterstützte Upload-Formate: mp4, mkv, mov, avi, wmv, webm, m4v, flv, ts.',
+      errUnsupportedFormat: 'Unterstützte Upload-Formate: mp4, mkv, mov, avi, wmv, webm, m4v, flv, ts, mpeg, mpg, m2ts, mts, 3gp, ogv, vob.',
       errUploadFailed: 'Video-Upload fehlgeschlagen.',
       errParseDisabled: 'Lokaler Upload-Modus ist aktiv. Online-URL-Analyse ist deaktiviert.',
       errDownloadDisabled: 'Dieses Projekt ist auf lokalen Upload-Modus gesperrt. Online-Download ist deaktiviert.',

--- a/src/components/VideoDownloader.tsx
+++ b/src/components/VideoDownloader.tsx
@@ -15,7 +15,7 @@ interface VideoDownloaderProps {
 }
 
 const VIDEO_UPLOAD_EXTENSIONS = new Set(['mp4', 'mkv', 'mov', 'avi', 'wmv', 'webm', 'm4v', 'flv', 'ts', 'mpeg', 'mpg', 'm2ts', 'mts', '3gp', 'ogv', 'vob']);
-const VIDEO_UPLOAD_ACCEPT = '.mp4,.mkv,.mov,.avi,.wmv,.webm,.m4v,.flv,.ts';
+const VIDEO_UPLOAD_ACCEPT = '.mp4,.mkv,.mov,.avi,.wmv,.webm,.m4v,.flv,.ts,.mpeg,.mpg,.m2ts,.mts,.3gp,.ogv,.vob';
 
 function getSourceModeCopy(language: Language) {
   const maps = {


### PR DESCRIPTION
## Summary

- normalize locally uploaded videos only when the original file is not browser-playable
- keep directly playable files as-is to avoid unnecessary remux/transcode work
- expand accepted local upload video extensions for common container formats
- make the upload size limit configurable with `APP_UPLOAD_MAX_BYTES`

## Validation

- `npm run -s check`
- verified playable MP4 uploads are kept as the original file
- verified non-browser-playable transport-style uploads are normalized to `source.mp4`
- reproduced and fixed the player path for local upload -> transcription -> translation -> player flow