### PR TITLE
feat: support advanced cloud model options and settings i18n

### DIFF
--- a/server/http/routes/settings_test_connection_route.ts
+++ b/server/http/routes/settings_test_connection_route.ts
@@ -1,5 +1,11 @@
 import express from 'express';
 import { resolveCloudAsrProvider } from '../../services/cloud_asr_provider.js';
+import type { ApiModelRequestOptions } from '../../../src/types.js';
+
+function sanitizeModelOptions(raw: unknown): ApiModelRequestOptions | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  return raw as ApiModelRequestOptions;
+}
 
 export interface SettingsTestConnectionRouteDeps {
   parseHttpUrl: (raw: string) => URL | null;
@@ -46,11 +52,13 @@ export function registerSettingsTestConnectionRoute(
       const requestedName = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
       const requestedUrl = typeof req.body?.url === 'string' ? req.body.url.trim() : '';
       const providedKey = typeof req.body?.key === 'string' ? req.body.key : '';
+      const requestedOptions = sanitizeModelOptions(req.body?.options);
 
       let finalUrl = requestedUrl;
       let finalKey = providedKey;
       let finalModel = requestedModel;
       let finalName = requestedName;
+      let finalOptions = requestedOptions;
 
       if (isMaskedKey(providedKey)) {
         if (!modelId) {
@@ -69,6 +77,7 @@ export function registerSettingsTestConnectionRoute(
         finalKey = String(found.key || '');
         finalModel = String(found.model || requestedModel || '');
         finalName = String(found.name || requestedName || '');
+        finalOptions = requestedOptions ?? sanitizeModelOptions(found.options);
       }
 
       if (finalKey && /[^\x20-\x7E]/.test(finalKey)) {
@@ -110,6 +119,7 @@ export function registerSettingsTestConnectionRoute(
           key: finalKey,
           model: finalModel,
           name: finalName,
+          options: finalOptions,
         });
         if (translatedConnection.success) {
           return res.json({ success: true, message: translatedConnection.message || 'Connection succeeded.' });

--- a/server/services/cloud_translate_adapter.ts
+++ b/server/services/cloud_translate_adapter.ts
@@ -4,6 +4,7 @@ import { llmAdapterRegistry } from './llm/adapters/registry.js';
 import type { LlmAdapterKey } from './llm/canonical/llm_capabilities.js';
 import { buildCanonicalTranslationRequest } from './llm/mapping/translation_canonical_request.js';
 import { deepLCloudTranslateAdapter } from './cloud_translate_deepl_adapter.js';
+import type { ApiModelRequestOptions } from '../../src/types.js';
 import {
   ollamaChatCloudTranslateAdapter,
   ollamaGenerateCloudTranslateAdapter,
@@ -18,6 +19,7 @@ export interface CloudTranslateAdapterRequestOptions {
   promptTemplateId?: string;
   key?: string;
   model?: string;
+  modelOptions?: ApiModelRequestOptions;
   isConnectionTest?: boolean;
   lineSafeMode?: boolean;
   systemPromptOverride?: string;
@@ -83,6 +85,100 @@ export interface CloudTranslateAdapter {
 
 ensureBuiltinLlmAdaptersRegistered();
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function toFiniteNumber(value: unknown): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseJsonSafe(raw: string | undefined) {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function parseOpenAiChatEventStream(rawText: string) {
+  const chunks = String(rawText || '').split(/\r?\n/);
+  let id = '';
+  let model = '';
+  let created = 0;
+  let finishReason: string | undefined;
+  let messageContent = '';
+  let reasoningContent = '';
+  let usage: Record<string, unknown> | undefined;
+  let sawChunk = false;
+
+  for (const line of chunks) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('data:')) continue;
+
+    const payload = trimmed.slice('data:'.length).trim();
+    if (!payload) continue;
+    if (payload === '[DONE]') break;
+
+    const parsed = parseJsonSafe(payload);
+    if (!parsed || typeof parsed !== 'object') continue;
+
+    sawChunk = true;
+    if (!id && typeof (parsed as any).id === 'string') id = (parsed as any).id;
+    if (!model && typeof (parsed as any).model === 'string') model = (parsed as any).model;
+    if (!created) {
+      const parsedCreated = Number((parsed as any).created);
+      if (Number.isFinite(parsedCreated) && parsedCreated > 0) created = parsedCreated;
+    }
+    if (isPlainObject((parsed as any).usage)) {
+      usage = (parsed as any).usage;
+    }
+
+    const choices = Array.isArray((parsed as any).choices) ? (parsed as any).choices : [];
+    for (const choice of choices) {
+      const delta = (choice as any)?.delta;
+      if (typeof delta?.content === 'string') {
+        messageContent += delta.content;
+      } else if (Array.isArray(delta?.content)) {
+        messageContent += delta.content
+          .map((part: any) => (typeof part?.text === 'string' ? part.text : typeof part === 'string' ? part : ''))
+          .join('');
+      }
+      if (typeof delta?.reasoning_content === 'string') {
+        reasoningContent += delta.reasoning_content;
+      }
+      if (!finishReason && typeof (choice as any)?.finish_reason === 'string' && (choice as any).finish_reason) {
+        finishReason = (choice as any).finish_reason;
+      }
+    }
+  }
+
+  if (!sawChunk) return null;
+
+  return {
+    id: id || undefined,
+    object: 'chat.completion',
+    created: created || Math.floor(Date.now() / 1000),
+    model: model || '',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: messageContent,
+          reasoning_content: reasoningContent || undefined,
+        },
+        finish_reason: finishReason || 'stop',
+      },
+    ],
+    usage,
+  };
+}
+
 async function executeLlmAdapterRequest(input: {
   adapterKey: LlmAdapterKey;
   providerFamily: CloudTranslateProvider;
@@ -104,6 +200,15 @@ async function executeLlmAdapterRequest(input: {
     isConnectionTest: input.options.isConnectionTest,
     promptTemplateId: input.options.promptTemplateId,
     glossary: input.options.glossary,
+    samplingOverrides: {
+      temperature: input.options.modelOptions?.sampling?.temperature,
+      topP: input.options.modelOptions?.sampling?.topP,
+      maxOutputTokens: input.options.modelOptions?.sampling?.maxOutputTokens,
+    },
+    providerHints: {
+      requestHeaders: input.options.modelOptions?.headers,
+      requestBody: input.options.modelOptions?.body,
+    },
   });
   const canonicalRequest = canonical.request;
 
@@ -113,14 +218,38 @@ async function executeLlmAdapterRequest(input: {
     modelOverride: canonicalRequest.model,
   });
 
+  const requestBody =
+    typeof providerRequest.body === 'string'
+      ? providerRequest.body
+      : providerRequest.body == null
+        ? undefined
+        : JSON.stringify(providerRequest.body);
+
+  const parsedRequestBody =
+    typeof requestBody === 'string' ? parseJsonSafe(requestBody) : null;
+  const isStreamingRequest = Boolean(
+    parsedRequestBody &&
+      typeof parsedRequestBody === 'object' &&
+      !Array.isArray(parsedRequestBody) &&
+      (parsedRequestBody as any).stream === true
+  );
+  const requestHeaders: Record<string, string> = { ...(providerRequest.headers || {}) };
+  const hasAcceptHeader = Object.keys(requestHeaders).some((key) => key.toLowerCase() === 'accept');
+  if (isStreamingRequest && !hasAcceptHeader) {
+    requestHeaders.Accept = 'text/event-stream';
+  }
+  const timeoutOverride = toFiniteNumber(input.options.modelOptions?.timeoutMs);
+  const effectiveTimeoutMs =
+    timeoutOverride && timeoutOverride > 0 ? timeoutOverride : providerRequest.timeoutMs ?? 120000;
+
   const response = await input.deps.fetchWithTimeout(
     providerRequest.url,
     {
       method: providerRequest.method,
-      headers: providerRequest.headers,
-      body: typeof providerRequest.body === 'string' ? providerRequest.body : JSON.stringify(providerRequest.body),
+      headers: requestHeaders,
+      body: requestBody,
     },
-    providerRequest.timeoutMs ?? 120000,
+    effectiveTimeoutMs,
     input.options.signal
   );
   const rawText = await response.text();
@@ -134,10 +263,18 @@ async function executeLlmAdapterRequest(input: {
   }
 
   let body: unknown = null;
-  try {
-    body = JSON.parse(rawText || '{}');
-  } catch {
-    body = rawText;
+  const contentType = String(response.headers.get('content-type') || '').toLowerCase();
+  const streamBody = isStreamingRequest || contentType.includes('text/event-stream')
+    ? parseOpenAiChatEventStream(rawText)
+    : null;
+  if (streamBody) {
+    body = streamBody;
+  } else {
+    try {
+      body = JSON.parse(rawText || '{}');
+    } catch {
+      body = rawText;
+    }
   }
 
   const parsed = adapter.parseResponse(

--- a/server/services/cloud_translate_adapter.ts
+++ b/server/services/cloud_translate_adapter.ts
@@ -105,7 +105,58 @@ function parseJsonSafe(raw: string | undefined) {
   }
 }
 
-function parseOpenAiChatEventStream(rawText: string) {
+type ParsedOpenAiChatEventStreamResult =
+  | { kind: 'completion'; body: Record<string, unknown> }
+  | { kind: 'error'; message: string; status?: number }
+  | null;
+
+function extractSseErrorFrame(parsed: any): { message: string; status?: number } | null {
+  if (!parsed || typeof parsed !== 'object') return null;
+
+  const topLevelError = parsed.error;
+  if (typeof topLevelError === 'string' && topLevelError.trim()) {
+    return { message: topLevelError.trim() };
+  }
+
+  if (isPlainObject(topLevelError)) {
+    const messageCandidate =
+      topLevelError.message ||
+      topLevelError.detail ||
+      topLevelError.error_description ||
+      topLevelError.error ||
+      parsed.message;
+    const statusCandidate =
+      topLevelError.status ?? topLevelError.http_status ?? topLevelError.status_code ?? topLevelError.code;
+    const parsedStatus = Number(statusCandidate);
+    const status =
+      Number.isFinite(parsedStatus) && parsedStatus >= 100 && parsedStatus <= 599 ? Math.round(parsedStatus) : undefined;
+    if (typeof messageCandidate === 'string' && messageCandidate.trim()) {
+      return {
+        message: messageCandidate.trim(),
+        status,
+      };
+    }
+  }
+
+  const objectType = String(parsed.object || parsed.type || '').toLowerCase();
+  if (
+    objectType.includes('error') &&
+    typeof parsed.message === 'string' &&
+    parsed.message.trim()
+  ) {
+    const parsedStatus = Number(parsed.status ?? parsed.code ?? 0);
+    const status =
+      Number.isFinite(parsedStatus) && parsedStatus >= 100 && parsedStatus <= 599 ? Math.round(parsedStatus) : undefined;
+    return {
+      message: parsed.message.trim(),
+      status,
+    };
+  }
+
+  return null;
+}
+
+function parseOpenAiChatEventStream(rawText: string): ParsedOpenAiChatEventStreamResult {
   const chunks = String(rawText || '').split(/\r?\n/);
   let id = '';
   let model = '';
@@ -127,7 +178,15 @@ function parseOpenAiChatEventStream(rawText: string) {
     const parsed = parseJsonSafe(payload);
     if (!parsed || typeof parsed !== 'object') continue;
 
-    sawChunk = true;
+    const sseError = extractSseErrorFrame(parsed);
+    if (sseError) {
+      return {
+        kind: 'error',
+        message: sseError.message,
+        status: sseError.status,
+      };
+    }
+
     if (!id && typeof (parsed as any).id === 'string') id = (parsed as any).id;
     if (!model && typeof (parsed as any).model === 'string') model = (parsed as any).model;
     if (!created) {
@@ -139,8 +198,12 @@ function parseOpenAiChatEventStream(rawText: string) {
     }
 
     const choices = Array.isArray((parsed as any).choices) ? (parsed as any).choices : [];
+    let frameHasChoicePayload = false;
     for (const choice of choices) {
       const delta = (choice as any)?.delta;
+      if (delta && typeof delta === 'object') {
+        frameHasChoicePayload = true;
+      }
       if (typeof delta?.content === 'string') {
         messageContent += delta.content;
       } else if (Array.isArray(delta?.content)) {
@@ -154,28 +217,38 @@ function parseOpenAiChatEventStream(rawText: string) {
       if (!finishReason && typeof (choice as any)?.finish_reason === 'string' && (choice as any).finish_reason) {
         finishReason = (choice as any).finish_reason;
       }
+      if (typeof (choice as any)?.finish_reason === 'string' && (choice as any).finish_reason) {
+        frameHasChoicePayload = true;
+      }
+    }
+
+    if (frameHasChoicePayload) {
+      sawChunk = true;
     }
   }
 
   if (!sawChunk) return null;
 
   return {
-    id: id || undefined,
-    object: 'chat.completion',
-    created: created || Math.floor(Date.now() / 1000),
-    model: model || '',
-    choices: [
-      {
-        index: 0,
-        message: {
-          role: 'assistant',
-          content: messageContent,
-          reasoning_content: reasoningContent || undefined,
+    kind: 'completion',
+    body: {
+      id: id || undefined,
+      object: 'chat.completion',
+      created: created || Math.floor(Date.now() / 1000),
+      model: model || '',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: messageContent,
+            reasoning_content: reasoningContent || undefined,
+          },
+          finish_reason: finishReason || 'stop',
         },
-        finish_reason: finishReason || 'stop',
-      },
-    ],
-    usage,
+      ],
+      usage,
+    },
   };
 }
 
@@ -264,11 +337,20 @@ async function executeLlmAdapterRequest(input: {
 
   let body: unknown = null;
   const contentType = String(response.headers.get('content-type') || '').toLowerCase();
-  const streamBody = isStreamingRequest || contentType.includes('text/event-stream')
-    ? parseOpenAiChatEventStream(rawText)
+  const streamResult =
+    isStreamingRequest || contentType.includes('text/event-stream')
+      ? parseOpenAiChatEventStream(rawText)
     : null;
-  if (streamBody) {
-    body = streamBody;
+  if (streamResult?.kind === 'error') {
+    throw input.deps.makeProviderHttpError(
+      input.errorPrefix,
+      streamResult.status ?? 502,
+      streamResult.message,
+      input.deps.parseRetryAfterMs(response)
+    );
+  }
+  if (streamResult?.kind === 'completion') {
+    body = streamResult.body;
   } else {
     try {
       body = JSON.parse(rawText || '{}');

--- a/server/services/llm/adapters/openai_chat_adapter.ts
+++ b/server/services/llm/adapters/openai_chat_adapter.ts
@@ -3,6 +3,25 @@ import type { CanonicalLlmRequest, CanonicalLlmResponse } from '../canonical/llm
 import { buildOpenAiChatMessages, wantsJsonObject, wantsJsonSchema } from '../mapping/provider_payloads.js';
 import type { LlmAdapter, LlmAdapterContext, ProviderHttpResponse } from './base.js';
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function deepMerge(base: Record<string, unknown>, override: Record<string, unknown>): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...base };
+  for (const [key, overrideValue] of Object.entries(override)) {
+    const baseValue = merged[key];
+    if (isPlainObject(baseValue) && isPlainObject(overrideValue)) {
+      merged[key] = deepMerge(baseValue, overrideValue);
+      continue;
+    }
+    merged[key] = overrideValue;
+  }
+  return merged;
+}
+
 function parseOpenAiLikeContent(content: any) {
   if (typeof content === 'string') return content;
   if (!Array.isArray(content)) return '';
@@ -78,11 +97,27 @@ function buildOpenAiChatRequest(input: CanonicalLlmRequest, context: LlmAdapterC
     };
   }
 
+  const requestHeaders = isPlainObject(input.providerHints?.requestHeaders)
+    ? (input.providerHints?.requestHeaders as Record<string, unknown>)
+    : null;
+  if (requestHeaders) {
+    for (const [key, value] of Object.entries(requestHeaders)) {
+      if (typeof value === 'string' && key.trim()) {
+        headers[key] = value;
+      }
+    }
+  }
+
+  const requestBody = isPlainObject(input.providerHints?.requestBody)
+    ? (input.providerHints?.requestBody as Record<string, unknown>)
+    : null;
+  const finalBody = requestBody ? deepMerge(body, requestBody) : body;
+
   return {
     method: 'POST' as const,
     url: context.endpointUrl,
     headers,
-    body: JSON.stringify(body),
+    body: JSON.stringify(finalBody),
     timeoutMs: 120000,
   };
 }

--- a/server/services/llm/mapping/translation_canonical_request.ts
+++ b/server/services/llm/mapping/translation_canonical_request.ts
@@ -16,6 +16,13 @@ export interface BuildCanonicalTranslationRequestInput {
   isConnectionTest?: boolean;
   promptTemplateId?: string;
   glossary?: string;
+  samplingOverrides?: {
+    temperature?: number | null;
+    topP?: number | null;
+    topK?: number | null;
+    maxOutputTokens?: number | null;
+  };
+  providerHints?: Record<string, unknown>;
 }
 
 export interface BuildCanonicalTranslationRequestResult {
@@ -35,23 +42,34 @@ function buildStructuredOutput(jsonResponse: boolean | undefined): CanonicalStru
   return jsonResponse ? { mode: 'json_object' } : { mode: 'text' };
 }
 
+function toFiniteNumber(value: unknown): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 export function buildCanonicalTranslationRequest(input: BuildCanonicalTranslationRequestInput): BuildCanonicalTranslationRequestResult {
   const providerTranslationProfile = resolveProviderTranslationProfile({
     providerFamily: input.providerFamily,
     runtimeFamily: input.adapterKey,
     modelName: input.model,
   });
+  const samplingOverrides = input.samplingOverrides || {};
+  const overrideTemperature = toFiniteNumber(samplingOverrides.temperature);
+  const overrideTopP = toFiniteNumber(samplingOverrides.topP);
+  const overrideTopK = toFiniteNumber(samplingOverrides.topK);
+  const overrideMaxOutputTokens = toFiniteNumber(samplingOverrides.maxOutputTokens);
   const baseRequest: CanonicalLlmRequest = {
     model: String(input.model || '').trim(),
     instructions: String(input.systemPrompt || '').trim() || undefined,
     messages: [buildUserMessage(input.text)],
     structuredOutput: buildStructuredOutput(input.jsonResponse),
     sampling: {
-      temperature: providerTranslationProfile?.arcsubDefaults.temperature ?? 0.2,
-      topP: providerTranslationProfile?.arcsubDefaults.topP,
-      topK: providerTranslationProfile?.arcsubDefaults.topK,
-      maxOutputTokens: input.isConnectionTest ? 32 : undefined,
+      temperature: overrideTemperature ?? providerTranslationProfile?.arcsubDefaults.temperature ?? 0.2,
+      topP: overrideTopP ?? providerTranslationProfile?.arcsubDefaults.topP,
+      topK: overrideTopK ?? providerTranslationProfile?.arcsubDefaults.topK,
+      maxOutputTokens: input.isConnectionTest ? 32 : overrideMaxOutputTokens,
     },
+    providerHints: input.providerHints,
     metadata: {
       targetLang: String(input.targetLang || '').trim(),
       sourceLang: String(input.sourceLang || '').trim(),

--- a/server/services/llm/orchestrators/cloud_translation_connection_probe.ts
+++ b/server/services/llm/orchestrators/cloud_translation_connection_probe.ts
@@ -4,12 +4,14 @@ import {
   type CloudTranslationOrchestratorInput,
 } from './cloud_translation_orchestrator.js';
 import { resolveCloudTranslateProvider, type ResolvedCloudTranslateProvider } from '../../cloud_translate_provider.js';
+import type { ApiModelRequestOptions } from '../../../../src/types.js';
 
 export interface CloudTranslationConnectionProbeInput {
   url: string;
   key?: string;
   model?: string;
   name?: string;
+  options?: ApiModelRequestOptions;
 }
 
 export interface CloudTranslationConnectionProbeResult {
@@ -28,7 +30,7 @@ export interface CloudTranslationConnectionProbeDeps {
       isConnectionTest: boolean;
     },
     resolvedProvider: ResolvedCloudTranslateProvider,
-    model: { key?: string; model?: string }
+    model: { key?: string; model?: string; options?: ApiModelRequestOptions }
   ): CloudTranslationOrchestratorInput;
   buildOrchestratorDeps(): CloudTranslationOrchestratorDeps;
   mapConnectionError(error: unknown): string;
@@ -42,6 +44,7 @@ export async function runCloudTranslationConnectionProbe(
   const key = String(input.key || '').trim();
   const model = String(input.model || '').trim();
   const name = String(input.name || '').trim();
+  const options = input.options;
 
   try {
     const resolvedProvider = resolveCloudTranslateProvider({
@@ -62,6 +65,7 @@ export async function runCloudTranslationConnectionProbe(
         {
           key,
           model: resolvedProvider.effectiveModel || model,
+          options,
         }
       ),
       deps.buildOrchestratorDeps()

--- a/server/services/llm/orchestrators/cloud_translation_orchestrator.ts
+++ b/server/services/llm/orchestrators/cloud_translation_orchestrator.ts
@@ -1,4 +1,5 @@
 import type { CloudTranslateProvider } from '../../cloud_translate_provider.js';
+import type { ApiModelRequestOptions } from '../../../../src/types.js';
 import {
   usesJsonStrictAlignment,
   usesTemplateValidatedQualityChecks,
@@ -50,6 +51,7 @@ export interface CloudTranslationProviderRequest {
   endpointUrl: string;
   key?: string;
   model?: string;
+  modelOptions?: ApiModelRequestOptions;
 }
 
 export interface CloudTranslationOrchestratorInput {
@@ -93,6 +95,7 @@ export interface CloudTranslationOrchestratorDeps {
       promptTemplateId?: string;
       key?: string;
       model?: string;
+      modelOptions?: ApiModelRequestOptions;
       isConnectionTest?: boolean;
       lineSafeMode?: boolean;
       systemPromptOverride?: string;
@@ -117,6 +120,7 @@ export interface CloudTranslationOrchestratorDeps {
       promptTemplateId?: string;
       key?: string;
       model?: string;
+      modelOptions?: ApiModelRequestOptions;
     },
     onProgress?: (message: string) => void,
     signal?: AbortSignal
@@ -230,6 +234,7 @@ export async function runCloudTranslationOrchestrator(
             promptTemplateId: input.promptTemplateId,
             key: input.providerRequest.key,
             model: input.providerRequest.model,
+            modelOptions: input.providerRequest.modelOptions,
             lineSafeMode: requestOptions.lineSafeMode,
             isConnectionTest: input.isConnectionTest,
             systemPromptOverride: String(requestOptions.promptOverride ?? input.prompt ?? '').trim(),
@@ -316,6 +321,7 @@ export async function runCloudTranslationOrchestrator(
             promptTemplateId: input.promptTemplateId,
             key: input.providerRequest.key,
             model: input.providerRequest.model,
+            modelOptions: input.providerRequest.modelOptions,
           },
           onProgress,
           input.signal
@@ -359,12 +365,13 @@ export async function runCloudTranslationOrchestrator(
           targetLang: input.targetLang,
           sourceLang: input.sourceLang,
           glossary: input.glossary,
-          promptTemplateId: input.promptTemplateId,
-          key: input.providerRequest.key,
-          model: input.providerRequest.model,
-        },
-        onProgress,
-        input.signal
+            promptTemplateId: input.promptTemplateId,
+            key: input.providerRequest.key,
+            model: input.providerRequest.model,
+            modelOptions: input.providerRequest.modelOptions,
+          },
+          onProgress,
+          input.signal
       );
 
       if (repaired) {

--- a/server/services/translation_service.ts
+++ b/server/services/translation_service.ts
@@ -58,6 +58,7 @@ import {
 } from './llm/orchestrators/translation_quality_policy.js';
 import type { ResolvedCloudTranslateProvider } from './cloud_translate_provider.js';
 import type { RunIssue } from '../../shared/run_monitor.js';
+import type { ApiModelRequestOptions } from '../../src/types.js';
 
 type TranslateProvider = CloudTranslateProvider | 'openvino-local';
 
@@ -81,6 +82,7 @@ interface TranslateRequestOptions {
   promptTemplateId?: PromptTemplateId | string;
   key?: string;
   model?: string;
+  modelOptions?: ApiModelRequestOptions;
   isConnectionTest?: boolean;
   lineSafeMode?: boolean;
   systemPromptOverride?: string;
@@ -2958,6 +2960,7 @@ export class TranslationService {
       promptTemplateId?: string;
       key?: string;
       model?: string;
+      modelOptions?: ApiModelRequestOptions;
     },
     onProgress?: TranslateProgressFn,
     signal?: AbortSignal
@@ -3012,6 +3015,7 @@ export class TranslationService {
           promptTemplateId: options.promptTemplateId,
           key: options.key,
           model: options.model,
+          modelOptions: options.modelOptions,
           lineSafeMode: false,
           signal,
         });
@@ -3059,6 +3063,7 @@ export class TranslationService {
           promptTemplateId: options.promptTemplateId,
           key: options.key,
           model: options.model,
+          modelOptions: options.modelOptions,
           lineSafeMode: false,
           systemPromptOverride: this.buildJsonLineRepairPrompt(options.targetLang, options.glossary, options.promptTemplateId),
           jsonResponse: true,
@@ -3235,7 +3240,7 @@ export class TranslationService {
       signal?: AbortSignal;
     },
     resolvedProvider: ResolvedCloudTranslateProvider,
-    model: { key?: string; model?: string }
+    model: { key?: string; model?: string; options?: ApiModelRequestOptions }
   ): CloudTranslationOrchestratorInput {
     const qualityMode = this.resolveTranslationQualityModeForRequest({
       promptTemplateId: input.promptTemplateId,
@@ -3258,6 +3263,7 @@ export class TranslationService {
         endpointUrl: resolvedProvider.endpointUrl,
         key: model.key,
         model: resolvedProvider.effectiveModel || model.model,
+        modelOptions: model.options,
       },
       signal: input.signal,
     };
@@ -3404,7 +3410,7 @@ export class TranslationService {
       signal?: AbortSignal;
     },
     resolvedProvider: ResolvedCloudTranslateProvider,
-    model: { key?: string; model?: string },
+    model: { key?: string; model?: string; options?: ApiModelRequestOptions },
     orchestrated: CloudTranslationOrchestratorResult,
     onProgress?: TranslateProgressFn
   ): Promise<{
@@ -3540,7 +3546,7 @@ export class TranslationService {
       signal?: AbortSignal;
     },
     resolvedProvider: ResolvedCloudTranslateProvider,
-    model: { key?: string; model?: string },
+    model: { key?: string; model?: string; options?: ApiModelRequestOptions },
     onProgress?: TranslateProgressFn
   ): Promise<TranslationResult> {
     const startedAt = Date.now();
@@ -3584,7 +3590,13 @@ export class TranslationService {
     };
   }
 
-  static async testConnection(input: { url: string; key?: string; model?: string; name?: string }) {
+  static async testConnection(input: {
+    url: string;
+    key?: string;
+    model?: string;
+    name?: string;
+    options?: ApiModelRequestOptions;
+  }) {
     return runCloudTranslationConnectionProbe(input, {
       buildOrchestratorInput: this.buildCloudTranslationOrchestratorInput.bind(this),
       buildOrchestratorDeps: this.buildCloudTranslationOrchestratorDeps.bind(this),
@@ -3658,6 +3670,7 @@ export class TranslationService {
       {
         key: model.key,
         model: model.model,
+        options: model.options,
       },
       onProgress
     );

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,10 +1,10 @@
 ﻿import React from 'react';
 import { Save, Plus, Globe, Key, Trash2, Info, Edit2, Check, ChevronDown, Zap, Loader2, AlertCircle, CheckCircle2, X } from 'lucide-react';
-import { ApiConfig, Project } from '../types';
+import { ApiConfig, ApiModelRequestOptions, Project } from '../types';
 import { useLanguage } from '../i18n/LanguageContext';
 import { Language } from '../i18n/translations';
 import { sanitizeInput, isValidUrl, isValidApiKey, maskApiKey, isMaskedApiKey } from '../utils/security';
-import { getJson, postJson } from '../utils/http_client';
+import { getJson, HttpRequestError, postJson } from '../utils/http_client';
 
 type LocalModelType = 'asr' | 'translate';
 
@@ -1224,7 +1224,9 @@ export default function Settings({ project }: { project: Project | null }) {
                 />
               </div>
               <div className="space-y-2">
-                <label className="block text-[10px] font-bold text-outline uppercase tracking-widest opacity-0">Save</label>
+                <label className="block text-[10px] font-bold text-outline uppercase tracking-widest opacity-0">
+                  {pyannoteCopy.saveToken}
+                </label>
                 <button
                   type="button"
                   onClick={() => void handleSavePyannoteToken()}
@@ -1235,7 +1237,9 @@ export default function Settings({ project }: { project: Project | null }) {
                 </button>
               </div>
               <div className="space-y-2">
-                <label className="block text-[10px] font-bold text-outline uppercase tracking-widest opacity-0">Install</label>
+                <label className="block text-[10px] font-bold text-outline uppercase tracking-widest opacity-0">
+                  {pyannoteCopy.install}
+                </label>
                 <button
                   type="button"
                   onClick={() => void handleInstallPyannote()}
@@ -1290,7 +1294,9 @@ export default function Settings({ project }: { project: Project | null }) {
                 />
               </div>
               <div className="space-y-2">
-                <label className="block text-[10px] font-bold text-outline uppercase tracking-widest opacity-0">Install</label>
+                <label className="block text-[10px] font-bold text-outline uppercase tracking-widest opacity-0">
+                  {t('settings.localInstall')}
+                </label>
                 <button
                   type="button"
                   onClick={() => void handleInstallLocalModel()}
@@ -1481,6 +1487,39 @@ export default function Settings({ project }: { project: Project | null }) {
   );
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function serializeModelOptions(options: ApiModelRequestOptions | undefined): string {
+  if (!options || !isPlainObject(options) || Object.keys(options).length === 0) return '';
+  try {
+    return JSON.stringify(options, null, 2);
+  } catch {
+    return '';
+  }
+}
+
+function parseModelOptions(raw: string): {
+  value?: ApiModelRequestOptions;
+  errorKey?: 'settings.advancedOptionsErrorObject' | 'settings.advancedOptionsErrorInvalidJson';
+} {
+  const trimmed = String(raw || '').trim();
+  if (!trimmed) return { value: undefined };
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (!isPlainObject(parsed)) {
+      return { errorKey: 'settings.advancedOptionsErrorObject' };
+    }
+    return { value: parsed as ApiModelRequestOptions };
+  } catch {
+    return { errorKey: 'settings.advancedOptionsErrorInvalidJson' };
+  }
+}
+
 const ModelItem: React.FC<{ 
   model: ApiConfig, 
   modelType: 'asr' | 'translate',
@@ -1499,24 +1538,77 @@ const ModelItem: React.FC<{
   const { t } = useLanguage();
   const [isEditing, setIsEditing] = React.useState(isNew);
   const [editedModel, setEditedModel] = React.useState(model);
+  const [modelOptionsText, setModelOptionsText] = React.useState(() => serializeModelOptions(model.options));
   const [testStatus, setTestStatus] = React.useState<'idle' | 'testing' | 'success' | 'failed'>('idle');
   const [testError, setTestError] = React.useState<string | null>(null);
-  const [errors, setErrors] = React.useState<{name?: string, url?: string, key?: string}>({});
+  const [errors, setErrors] = React.useState<{name?: string, url?: string, key?: string, options?: string}>({});
 
-  const validate = (data: ApiConfig) => {
-    const newErrors: {name?: string, url?: string, key?: string} = {};
+  React.useEffect(() => {
+    if (isEditing) return;
+    setEditedModel(model);
+    setModelOptionsText(serializeModelOptions(model.options));
+  }, [isEditing, model]);
+
+  const validate = (data: ApiConfig, optionsError?: string | null) => {
+    const newErrors: {name?: string, url?: string, key?: string, options?: string} = {};
     if (!data.name.trim()) newErrors.name = t('settings.errorNameRequired');
     if (!isValidUrl(data.url)) newErrors.url = t('settings.errorInvalidUrl');
     if (data.key && !isValidApiKey(data.key) && !isMaskedApiKey(data.key)) {
       newErrors.key = t('settings.errorInvalidKey');
+    }
+    if (modelType === 'translate' && optionsError) {
+      newErrors.options = optionsError;
     }
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
 
   const handleTestConnection = async () => {
-    const target = isEditing ? editedModel : model;
+    const parsedOptions = isEditing && modelType === 'translate' ? parseModelOptions(modelOptionsText) : {};
+    if (parsedOptions.errorKey) {
+      const localized = t(parsedOptions.errorKey);
+      setErrors((prev) => ({ ...prev, options: localized }));
+      setTestStatus('failed');
+      setTestError(localized);
+      setTimeout(() => {
+        setTestStatus('idle');
+      }, 5000);
+      return;
+    }
+
+    const target = isEditing
+      ? {
+          ...editedModel,
+          options: modelType === 'translate' ? parsedOptions.value : editedModel.options,
+        }
+      : model;
     if (!target.url) return;
+    const configuredTimeoutMs = Number(target.options?.timeoutMs);
+    const connectionTimeoutMs =
+      Number.isFinite(configuredTimeoutMs) && configuredTimeoutMs > 0
+        ? Math.round(configuredTimeoutMs)
+        : modelType === 'translate'
+          ? 120_000
+          : 20_000;
+
+    const parseHttpErrorBody = (bodyText: string) => {
+      const raw = String(bodyText || '').trim();
+      if (!raw) return '';
+      try {
+        const parsed = JSON.parse(raw);
+        const nested = parsed?.error;
+        const nestedMessage =
+          typeof nested === 'string'
+            ? nested
+            : nested?.message || parsed?.message || parsed?.detail || parsed?.error_description;
+        if (typeof nestedMessage === 'string' && nestedMessage.trim()) {
+          return nestedMessage.trim();
+        }
+      } catch {
+        // Non-JSON body; use raw text.
+      }
+      return raw;
+    };
     
     setTestStatus('testing');
     setTestError(null);
@@ -1530,8 +1622,9 @@ const ModelItem: React.FC<{
           modelId: target.id,
           model: target.model || '',
           name: target.name || '',
+          options: target.options,
         },
-        { timeoutMs: 12_000, retries: 0 }
+        { timeoutMs: connectionTimeoutMs, retries: 0 }
       );
       
       if (data.success) {
@@ -1542,7 +1635,19 @@ const ModelItem: React.FC<{
       }
     } catch (error: any) {
       setTestStatus('failed');
-      setTestError(error.message || t('settings.testFailed'));
+      const rawMessage = String(error?.message || '').trim();
+      const isAbortLike = error?.name === 'AbortError' || /abort|aborted|timeout/i.test(rawMessage);
+      if (isAbortLike) {
+        const timeoutMessage = t('settings.connectionTimeout').replace(
+          '{seconds}',
+          String(Math.round(connectionTimeoutMs / 1000))
+        );
+        setTestError(timeoutMessage);
+      } else if (error instanceof HttpRequestError) {
+        setTestError(parseHttpErrorBody(error.bodyText) || rawMessage || t('settings.testFailed'));
+      } else {
+        setTestError(rawMessage || t('settings.testFailed'));
+      }
     } finally {
       // Always reset to idle after 5 seconds to let user try again
       setTimeout(() => {
@@ -1552,13 +1657,16 @@ const ModelItem: React.FC<{
   };
 
   const handleSave = () => {
+    const parsedOptions = modelType === 'translate' ? parseModelOptions(modelOptionsText) : {};
     const sanitized = {
       ...editedModel,
       name: sanitizeInput(editedModel.name),
       url: editedModel.url.trim(),
-      key: editedModel.key.trim()
+      key: editedModel.key.trim(),
+      options: modelType === 'translate' ? parsedOptions.value : editedModel.options,
     };
-    if (!validate(sanitized)) return;
+    const optionsError = parsedOptions.errorKey ? t(parsedOptions.errorKey) : null;
+    if (!validate(sanitized, optionsError)) return;
     onSave(sanitized);
     setIsEditing(false);
   };
@@ -1568,6 +1676,7 @@ const ModelItem: React.FC<{
       onCancelNew();
     } else {
       setEditedModel(model);
+      setModelOptionsText(serializeModelOptions(model.options));
       setIsEditing(false);
     }
   };
@@ -1604,6 +1713,18 @@ const ModelItem: React.FC<{
                 {model.model || (modelType === 'asr' ? 'whisper-1' : 'gpt-4o-mini')}
               </div>
             </div>
+            {modelType === 'translate' && model.options && (
+              <div className="rounded-xl border border-white/5 bg-surface-container-high px-4 py-3 sm:col-span-2">
+                <div className="text-[10px] font-bold uppercase tracking-widest text-outline">
+                  {t('settings.advancedOptionsTitle')}
+                </div>
+                <div className="mt-1 truncate text-xs text-secondary">
+                  {Object.keys(model.options).length > 0
+                    ? t('settings.advancedOptionsConfigured')
+                    : t('settings.notSet')}
+                </div>
+              </div>
+            )}
           </div>
 
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
@@ -1728,6 +1849,32 @@ const ModelItem: React.FC<{
           />
           <p className="text-[10px] text-outline/50 mt-1">{t('settings.modelIdHint')}</p>
         </div>
+        {modelType === 'translate' && (
+          <div className="space-y-2 md:col-span-2 xl:col-span-4">
+            <label className="text-[10px] font-bold text-primary uppercase tracking-widest">
+              {t('settings.advancedOptionsJsonTitle')}
+            </label>
+            <textarea
+              value={modelOptionsText}
+              onChange={(e) => {
+                setModelOptionsText(e.target.value);
+                if (errors.options) setErrors({ ...errors, options: undefined });
+              }}
+              placeholder={`{\n  \"sampling\": {\n    \"temperature\": 1,\n    \"topP\": 0.95,\n    \"maxOutputTokens\": 16384\n  },\n  \"body\": {\n    \"stream\": true,\n    \"chat_template_kwargs\": {\n      \"enable_thinking\": true,\n      \"clear_thinking\": false\n    }\n  },\n  \"headers\": {\n    \"Accept\": \"text/event-stream\"\n  },\n  \"timeoutMs\": 180000\n}`}
+              rows={12}
+              className={`w-full bg-surface-container-lowest border rounded-xl text-sm py-3.5 px-4 text-secondary font-mono focus:ring-2 focus:ring-primary-container outline-none transition-all placeholder:text-outline/30 ${
+                errors.options ? 'border-error/50' : 'border-white/10'
+              }`}
+            />
+            {errors.options ? (
+              <p className="text-[10px] text-error font-bold mt-1">{errors.options}</p>
+            ) : (
+              <p className="text-[10px] text-outline/50 mt-1">
+                {t('settings.advancedOptionsHint')}
+              </p>
+            )}
+          </div>
+        )}
       </div>
       
       <div className="flex flex-col gap-3 border-t border-white/5 pt-6 sm:flex-row sm:justify-end">

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -3523,6 +3523,63 @@ const monitorSectionOverrides: Record<Language, Record<string, string>> = {
   Object.assign(translations[language], translationPipelineMessagingOverrides[language]);
 });
 
+const settingsAdvancedOptionsOverrides: Record<Language, Record<string, string>> = {
+  'zh-tw': {
+    'settings.advancedOptionsTitle': '進階請求參數',
+    'settings.advancedOptionsJsonTitle': '進階請求參數（JSON）',
+    'settings.advancedOptionsConfigured': '已設定',
+    'settings.advancedOptionsHint':
+      '支援 OpenAI 相容 API 的完整 provider 參數，包括 stream 與 chat_template_kwargs。',
+    'settings.advancedOptionsErrorObject': '進階參數必須是 JSON 物件。',
+    'settings.advancedOptionsErrorInvalidJson': '進階參數 JSON 格式無效。',
+    'settings.connectionTimeout': '連線逾時（{seconds} 秒）。',
+  },
+  'zh-cn': {
+    'settings.advancedOptionsTitle': '高级请求参数',
+    'settings.advancedOptionsJsonTitle': '高级请求参数（JSON）',
+    'settings.advancedOptionsConfigured': '已配置',
+    'settings.advancedOptionsHint':
+      '支持 OpenAI 兼容 API 的完整 provider 参数，包括 stream 和 chat_template_kwargs。',
+    'settings.advancedOptionsErrorObject': '高级参数必须是 JSON 对象。',
+    'settings.advancedOptionsErrorInvalidJson': '高级参数 JSON 格式无效。',
+    'settings.connectionTimeout': '连接超时（{seconds} 秒）。',
+  },
+  en: {
+    'settings.advancedOptionsTitle': 'Advanced Request Options',
+    'settings.advancedOptionsJsonTitle': 'Advanced Request Options (JSON)',
+    'settings.advancedOptionsConfigured': 'Configured',
+    'settings.advancedOptionsHint':
+      'Supports full provider parameters for OpenAI-compatible APIs, including stream and chat_template_kwargs.',
+    'settings.advancedOptionsErrorObject': 'Advanced options must be a JSON object.',
+    'settings.advancedOptionsErrorInvalidJson': 'Advanced options JSON is invalid.',
+    'settings.connectionTimeout': 'Connection timeout ({seconds}s).',
+  },
+  jp: {
+    'settings.advancedOptionsTitle': '高度なリクエスト設定',
+    'settings.advancedOptionsJsonTitle': '高度なリクエスト設定（JSON）',
+    'settings.advancedOptionsConfigured': '設定済み',
+    'settings.advancedOptionsHint':
+      'OpenAI 互換 API 向けに、stream や chat_template_kwargs を含む全ての provider パラメータを指定できます。',
+    'settings.advancedOptionsErrorObject': '高度な設定は JSON オブジェクトである必要があります。',
+    'settings.advancedOptionsErrorInvalidJson': '高度な設定の JSON が無効です。',
+    'settings.connectionTimeout': '接続がタイムアウトしました（{seconds}秒）。',
+  },
+  de: {
+    'settings.advancedOptionsTitle': 'Erweiterte Anfrageoptionen',
+    'settings.advancedOptionsJsonTitle': 'Erweiterte Anfrageoptionen (JSON)',
+    'settings.advancedOptionsConfigured': 'Konfiguriert',
+    'settings.advancedOptionsHint':
+      'Unterstuetzt vollstaendige Provider-Parameter fuer OpenAI-kompatible APIs, einschliesslich stream und chat_template_kwargs.',
+    'settings.advancedOptionsErrorObject': 'Erweiterte Optionen muessen ein JSON-Objekt sein.',
+    'settings.advancedOptionsErrorInvalidJson': 'JSON fuer erweiterte Optionen ist ungueltig.',
+    'settings.connectionTimeout': 'Zeitueberschreitung bei der Verbindung ({seconds}s).',
+  },
+};
+
+(Object.keys(settingsAdvancedOptionsOverrides) as Language[]).forEach((language) => {
+  Object.assign(translations[language], settingsAdvancedOptionsOverrides[language]);
+});
+
 type PromptTargetLanguage =
   | 'zh-tw'
   | 'zh-cn'

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,8 +73,22 @@ export interface ApiConfig {
   url: string;
   key: string;
   model?: string;
+  options?: ApiModelRequestOptions;
   isLocal?: boolean;
   provider?: 'cloud' | 'local-openvino';
+}
+
+export interface ApiModelSamplingOptions {
+  temperature?: number | null;
+  topP?: number | null;
+  maxOutputTokens?: number | null;
+}
+
+export interface ApiModelRequestOptions {
+  sampling?: ApiModelSamplingOptions;
+  headers?: Record<string, string>;
+  body?: Record<string, unknown>;
+  timeoutMs?: number | null;
 }
 
 export interface LocalModelSelection {


### PR DESCRIPTION
## Summary
- add configurable per-model cloud request options in settings (`sampling`, `body`, `headers`, `timeoutMs`)
- propagate model options through translation test/connection/orchestrator flow into OpenAI-compatible adapter requests
- add SSE parsing fallback handling for streamed OpenAI-compatible responses
- localize newly added Settings UI copy for advanced options across all supported languages

## Key Changes
- backend option plumbing:
  - `server/http/routes/settings_test_connection_route.ts`
  - `server/services/translation_service.ts`
  - `server/services/llm/orchestrators/cloud_translation_connection_probe.ts`
  - `server/services/llm/orchestrators/cloud_translation_orchestrator.ts`
  - `server/services/llm/mapping/translation_canonical_request.ts`
  - `server/services/llm/adapters/openai_chat_adapter.ts`
  - `server/services/cloud_translate_adapter.ts`
- shared types:
  - `src/types.ts`
- settings UI + i18n:
  - `src/components/Settings.tsx`
  - `src/i18n/translations.ts`

## Validation
- `npm run -s typecheck`
- `npx tsc -p tsconfig.server.json --noEmit`
- `npm run -s build`
