### PR TITLE
[codex] Add local ASR runtime improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -199,6 +199,18 @@ OPENVINO_HELPER_SHUTDOWN_TIMEOUT_MS=4000
 # OPENVINO_QWEN3_ASR_FORCED_ALIGNER_DEVICE=cpu
 # OPENVINO_QWEN3_ASR_FORCED_ALIGNER_DTYPE=float32
 
+# HF Transformers ASR models such as Cohere Transcribe use an isolated
+# Transformers 5.x runtime under runtime/tools/python so they do not affect
+# OpenVINO / Optimum ASR conversions.
+# HF_TRANSFORMERS_ASR_MAX_NEW_TOKENS=256
+
+# Cohere Transcribe OpenVINO ASR export/runtime
+# ArcSub exports CohereLabs/cohere-transcribe-03-2026 into a Cohere-specific
+# OpenVINO INT8 forward runtime, then performs greedy ASR decoding in the helper.
+# OPENVINO_COHERE_ASR_EXPORT_EXAMPLE_SECONDS=8
+# OPENVINO_COHERE_ASR_CHUNK_SEC=30
+# OPENVINO_COHERE_ASR_MAX_NEW_TOKENS=256
+
 # ============================================================================
 # 8) OpenVINO Translation Runtime Tuning (advanced)
 # ============================================================================

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,30 @@
   "files.encoding": "utf8",
   "files.autoGuessEncoding": false,
   "files.eol": "\n",
+  "terminal.integrated.defaultProfile.windows": "PowerShell UTF-8",
+  "terminal.integrated.profiles.windows": {
+    "PowerShell UTF-8": {
+      "source": "PowerShell",
+      "args": [
+        "-NoLogo",
+        "-NoExit",
+        "-Command",
+        "$utf8 = [System.Text.UTF8Encoding]::new($false); [Console]::InputEncoding = $utf8; [Console]::OutputEncoding = $utf8; $OutputEncoding = $utf8; chcp 65001 | Out-Null"
+      ],
+      "env": {
+        "PYTHONUTF8": "1",
+        "PYTHONIOENCODING": "utf-8",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8"
+      }
+    }
+  },
+  "terminal.integrated.env.windows": {
+    "PYTHONUTF8": "1",
+    "PYTHONIOENCODING": "utf-8",
+    "LANG": "C.UTF-8",
+    "LC_ALL": "C.UTF-8"
+  },
   "[powershell]": {
     "files.eol": "\r\n"
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,7 @@
     "LANG": "C.UTF-8",
     "LC_ALL": "C.UTF-8"
   },
+  "powershell.integratedConsole.showOnStartup": false,
   "[powershell]": {
     "files.eol": "\r\n"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2663,6 +2664,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4541,6 +4543,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4561,9 +4564,9 @@
       "license": "MIT"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4579,6 +4582,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4703,6 +4707,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4712,6 +4717,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5219,6 +5225,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -5374,6 +5381,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/scripts/install-deployment-assets.mjs
+++ b/scripts/install-deployment-assets.mjs
@@ -45,23 +45,6 @@ async function loadBuiltModule(rootDir, relativePath) {
   return import(pathToFileURL(absolutePath).href);
 }
 
-async function downloadFile(url, destination) {
-  await fs.ensureDir(path.dirname(destination));
-  const tempPath = `${destination}.part`;
-  const response = await fetch(url, {
-    redirect: 'follow',
-    headers: {
-      'User-Agent': 'ArcSub-Deploy/1.0',
-    },
-  });
-  if (!response.ok) {
-    throw new Error(`Failed to download ${url} (${response.status})`);
-  }
-  const buffer = Buffer.from(await response.arrayBuffer());
-  await fs.writeFile(tempPath, buffer);
-  await fs.move(tempPath, destination, { overwrite: true });
-}
-
 async function hasConfiguredEnvValue(rootDir, key) {
   if (String(process.env[key] || '').trim()) return true;
   const envPath = path.join(rootDir, '.env');
@@ -69,23 +52,6 @@ async function hasConfiguredEnvValue(rootDir, key) {
   const content = await fs.readFile(envPath, 'utf8');
   const matched = content.match(new RegExp(`^${key}=(.+)$`, 'm'));
   return Boolean(String(matched?.[1] || '').trim());
-}
-
-async function ensureRequiredAssets(manifest, modelsPath) {
-  const installed = [];
-  const skipped = [];
-
-  for (const asset of manifest.assets?.required || []) {
-    const destination = path.join(modelsPath, asset.targetRelativePath);
-    if (await fs.pathExists(destination)) {
-      skipped.push({ id: asset.id, path: destination });
-      continue;
-    }
-    await downloadFile(asset.sourceUrl, destination);
-    installed.push({ id: asset.id, path: destination });
-  }
-
-  return { installed, skipped };
 }
 
 function printSummary(snapshot, assetSummary, pyannoteSummary) {
@@ -121,7 +87,7 @@ async function main() {
   await PathManager.ensureBaseDirs();
   await ResourceManager.ensureTools();
 
-  const assetSummary = await ensureRequiredAssets(manifest, PathManager.getModelsPath());
+  const assetSummary = await ResourceManager.ensureRequiredBaselineAssets(manifest);
 
   const pyannoteSummary = {
     status: 'skipped',

--- a/server/local_model_catalog.ts
+++ b/server/local_model_catalog.ts
@@ -7,6 +7,8 @@ export type LocalModelRuntime =
   | 'openvino-whisper-node'
   | 'openvino-ctc-asr'
   | 'openvino-qwen3-asr'
+  | 'openvino-cohere-asr'
+  | 'hf-transformers-asr'
   | 'openvino-seq2seq-translate'
   | 'openvino-llm-node';
 export type LocalModelInstallMode = 'hf-direct' | 'hf-qwen3-asr-convert' | 'hf-auto-convert';
@@ -27,11 +29,14 @@ export type LocalModelConversionMethod =
   | 'optimum-export-openvino'
   | 'openvino-ctc-asr-export'
   | 'openvino-qwen3-asr-export'
+  | 'openvino-cohere-asr-export'
   | 'unsupported';
 export type LocalModelRuntimeLayout =
   | 'asr-whisper'
   | 'asr-ctc'
   | 'asr-qwen3-official'
+  | 'asr-cohere-ov'
+  | 'asr-hf-transformers'
   | 'translate-llm'
   | 'translate-seq2seq'
   | 'translate-vlm';
@@ -198,6 +203,36 @@ const QWEN3_ASR_OFFICIAL_CONVERTED_OPTIONAL_FILES = [
   'added_tokens.json',
   'special_tokens_map.json',
   'tokenizer.json',
+];
+
+const HF_TRANSFORMERS_ASR_REQUIRED_FILES = [
+  'config.json',
+  'generation_config.json',
+  'preprocessor_config.json',
+  'processor_config.json',
+  'tokenizer_config.json',
+  'special_tokens_map.json',
+  'tokenizer.json',
+  'tokenizer.model',
+  'model.safetensors',
+  'configuration_cohere_asr.py',
+  'modeling_cohere_asr.py',
+  'processing_cohere_asr.py',
+  'tokenization_cohere_asr.py',
+];
+
+const COHERE_ASR_OV_REQUIRED_FILES = [
+  'config.json',
+  'generation_config.json',
+  'preprocessor_config.json',
+  'processor_config.json',
+  'tokenizer_config.json',
+  'special_tokens_map.json',
+  'tokenizer.json',
+  'tokenizer.model',
+  'openvino_model.xml',
+  'openvino_model.bin',
+  'arcsub_cohere_asr_ov_config.json',
 ];
 
 const TRANSLATE_SHARED_REQUIRED_FILES = [
@@ -432,6 +467,10 @@ function getRequiredFilesForRuntimeLayout(layout: LocalModelRuntimeLayout, fileS
       return fileSet
         ? pickExistingFiles(fileSet, [...getOfficialQwen3AsrConvertedRequiredFiles(fileSet), ...QWEN3_ASR_OFFICIAL_CONVERTED_OPTIONAL_FILES])
         : getOfficialQwen3AsrConvertedRequiredFiles();
+    case 'asr-cohere-ov':
+      return fileSet ? pickExistingFiles(fileSet, COHERE_ASR_OV_REQUIRED_FILES) : [...COHERE_ASR_OV_REQUIRED_FILES];
+    case 'asr-hf-transformers':
+      return fileSet ? pickExistingFiles(fileSet, HF_TRANSFORMERS_ASR_REQUIRED_FILES) : [...HF_TRANSFORMERS_ASR_REQUIRED_FILES];
     case 'translate-vlm':
       return fileSet
         ? pickExistingFiles(
@@ -465,6 +504,31 @@ function inferRuntimeLayoutFromArtifacts(type: LocalModelType, fileSet: Set<stri
       QWEN3_ASR_OFFICIAL_CONVERTED_BASE_REQUIRED_FILES.every((file) => fileSet.has(file));
     if (hasOfficialQwenLayout) {
       return 'asr-qwen3-official';
+    }
+
+    const hasCohereOvLayout =
+      fileSet.has('arcsub_cohere_asr_ov_config.json') &&
+      fileSet.has('openvino_model.xml') &&
+      fileSet.has('openvino_model.bin') &&
+      fileSet.has('config.json') &&
+      fileSet.has('preprocessor_config.json') &&
+      fileSet.has('processor_config.json') &&
+      fileSet.has('tokenizer_config.json');
+    if (hasCohereOvLayout) {
+      return 'asr-cohere-ov';
+    }
+
+    const hasCohereTransformersLayout =
+      fileSet.has('configuration_cohere_asr.py') &&
+      fileSet.has('modeling_cohere_asr.py') &&
+      fileSet.has('processing_cohere_asr.py') &&
+      fileSet.has('tokenization_cohere_asr.py') &&
+      fileSet.has('model.safetensors') &&
+      fileSet.has('config.json') &&
+      fileSet.has('preprocessor_config.json') &&
+      fileSet.has('tokenizer_config.json');
+    if (hasCohereTransformersLayout) {
+      return 'asr-hf-transformers';
     }
 
     const hasCtcTokenizerFile = CTC_ASR_TOKENIZER_FILES.some((file) => fileSet.has(file));
@@ -502,6 +566,10 @@ function inferRuntimeFromLayout(layout: LocalModelRuntimeLayout | null): LocalMo
       return 'openvino-ctc-asr';
     case 'asr-qwen3-official':
       return 'openvino-qwen3-asr';
+    case 'asr-cohere-ov':
+      return 'openvino-cohere-asr';
+    case 'asr-hf-transformers':
+      return 'hf-transformers-asr';
     case 'translate-llm':
       return 'openvino-llm-node';
     case 'translate-seq2seq':
@@ -520,6 +588,8 @@ function normalizeRuntimeValue(input: any, runtimeLayout: LocalModelRuntimeLayou
   if (
     input.runtime === 'openvino-whisper-node' ||
     input.runtime === 'openvino-ctc-asr' ||
+    input.runtime === 'openvino-cohere-asr' ||
+    input.runtime === 'hf-transformers-asr' ||
     input.runtime === 'openvino-seq2seq-translate' ||
     input.runtime === 'openvino-llm-node'
   ) {
@@ -549,6 +619,7 @@ function inferDirectSourceFormatFromArtifacts(fileSet: Set<string>) {
 
 function inferSourceFormatFromStoredDefinition(input: any, fileSet: Set<string>): LocalModelSourceFormat {
   const runtimeLayout = inferRuntimeLayoutFromStoredDefinition(input);
+  if (runtimeLayout === 'asr-hf-transformers') return 'pytorch';
   if (runtimeLayout) return 'openvino-ir';
   return inferDirectSourceFormatFromArtifacts(fileSet);
 }
@@ -563,12 +634,16 @@ function inferConversionMethodFromStoredDefinition(
       input?.conversionMethod === 'optimum-export-openvino' ||
       input?.conversionMethod === 'openvino-ctc-asr-export' ||
       input?.conversionMethod === 'openvino-qwen3-asr-export' ||
+      input?.conversionMethod === 'openvino-cohere-asr-export' ||
       input?.conversionMethod === 'unsupported') {
     return input.conversionMethod;
   }
 
   if (input?.installMode === 'hf-qwen3-asr-convert') {
     return 'openvino-qwen3-asr-export';
+  }
+  if (runtimeLayout === 'asr-hf-transformers') {
+    return 'direct-download';
   }
   if (input?.installMode === 'hf-auto-convert') {
     if (
@@ -672,6 +747,9 @@ function guessRuntimeLayoutFromMetadata(
       return 'asr-qwen3-official';
     }
     const modelType = String(metadata?.config?.model_type || '').trim().toLowerCase();
+    if (modelType === 'cohere_asr') {
+      return 'asr-cohere-ov';
+    }
     const architectures = Array.isArray(metadata?.config?.architectures)
       ? metadata!.config!.architectures!.map((item) => String(item || '').trim().toLowerCase())
       : [];
@@ -735,6 +813,12 @@ function inferConversionMethodFromHfMetadata(
   }
   if (type === 'asr' && isOfficialQwen3AsrRepo(repoId)) {
     return 'openvino-qwen3-asr-export';
+  }
+  if (type === 'asr' && runtimeLayout === 'asr-hf-transformers') {
+    return 'direct-download';
+  }
+  if (type === 'asr' && runtimeLayout === 'asr-cohere-ov') {
+    return 'openvino-cohere-asr-export';
   }
   if (sourceFormat === 'gguf') {
     return 'unsupported';
@@ -919,6 +1003,20 @@ export const BUILTIN_LOCAL_MODELS: LocalModelDefinition[] = [
     ],
     runtime: 'openvino-whisper-node',
     installMode: 'hf-direct',
+    device: 'AUTO',
+  }),
+  createBuiltInModel({
+    id: 'local_asr_coherelabs_cohere_transcribe_03_2026',
+    type: 'asr',
+    displayName: 'Cohere Transcribe 03 2026',
+    repoId: 'CohereLabs/cohere-transcribe-03-2026',
+    localSubdir: 'openvino/CohereLabs--cohere-transcribe-03-2026-int8-ov',
+    requiredFiles: [...COHERE_ASR_OV_REQUIRED_FILES],
+    runtime: 'openvino-cohere-asr',
+    runtimeLayout: 'asr-cohere-ov',
+    sourceFormat: 'pytorch',
+    conversionMethod: 'openvino-cohere-asr-export',
+    installMode: 'hf-auto-convert',
     device: 'AUTO',
   }),
   createBuiltInModel({
@@ -1266,6 +1364,8 @@ export function sanitizeLocalModelDefinition(input: any): LocalModelDefinition |
     input.runtimeLayout === 'asr-whisper' ||
     input.runtimeLayout === 'asr-ctc' ||
     input.runtimeLayout === 'asr-qwen3-official' ||
+    input.runtimeLayout === 'asr-cohere-ov' ||
+    input.runtimeLayout === 'asr-hf-transformers' ||
     input.runtimeLayout === 'translate-llm' ||
     input.runtimeLayout === 'translate-seq2seq' ||
     input.runtimeLayout === 'translate-vlm'
@@ -1413,6 +1513,7 @@ export function inferLocalModelDefinitionFromHf(
   const fileSet = new Set(allFiles);
   const pipelineTag = String(metadata?.pipeline_tag || '').trim().toLowerCase();
   const tags = normalizeTagSet(metadata);
+  const modelType = String(metadata?.config?.model_type || '').trim().toLowerCase();
 
   if (type === 'translate' && (pipelineTag === 'automatic-speech-recognition' || tags.has('automatic-speech-recognition'))) {
     throw new Error('This Hugging Face model is an ASR model, not a translation model.');
@@ -1421,12 +1522,18 @@ export function inferLocalModelDefinitionFromHf(
     throw new Error('This Hugging Face model is not tagged as an ASR model.');
   }
 
-  const directDefinition = buildDefinitionFromArtifactFiles(type, repoId, fileSet, {
-    installMode: 'hf-direct',
-    sourceFormat: 'openvino-ir',
-    conversionMethod: 'direct-download',
-    source: 'custom',
-  });
+  const directDefinition =
+    modelType === 'cohere_asr' && type === 'asr'
+      ? null
+      : buildDefinitionFromArtifactFiles(type, repoId, fileSet, {
+          installMode: 'hf-direct',
+          sourceFormat:
+            inferRuntimeLayoutFromArtifacts(type, fileSet) === 'asr-hf-transformers'
+              ? 'pytorch'
+              : inferDirectSourceFormatFromArtifacts(fileSet),
+          conversionMethod: 'direct-download',
+          source: 'custom',
+        });
   if (directDefinition) {
     return directDefinition;
   }
@@ -1477,7 +1584,12 @@ export function inferLocalModelDefinitionFromHf(
     requiredFiles: getRequiredFilesForRuntimeLayout(runtimeLayout),
     runtime,
     runtimeLayout,
-    installMode: conversionMethod === 'openvino-qwen3-asr-export' ? 'hf-qwen3-asr-convert' : 'hf-auto-convert',
+    installMode:
+      conversionMethod === 'openvino-qwen3-asr-export'
+        ? 'hf-qwen3-asr-convert'
+        : conversionMethod === 'direct-download'
+          ? 'hf-direct'
+          : 'hf-auto-convert',
     sourceFormat,
     conversionMethod,
     device: 'AUTO',

--- a/server/openvino_runtime_manager.ts
+++ b/server/openvino_runtime_manager.ts
@@ -1228,6 +1228,17 @@ export class OpenvinoRuntimeManager {
     return this.isOpenvinoGpuAllocationLimitError(error) || this.isOpenvinoRemoteTensorNotImplementedError(error);
   }
 
+  private static isAsrHelperDeviceCompatible(
+    helperDevice: string | null | undefined,
+    requestedDevice: string,
+    allowCpuFallback: boolean
+  ) {
+    const normalizedHelperDevice = this.normalizeRequestedDevice(helperDevice, requestedDevice);
+    if (normalizedHelperDevice === requestedDevice) return true;
+    if (requestedDevice === 'AUTO' && normalizedHelperDevice) return true;
+    return allowCpuFallback && normalizedHelperDevice === 'CPU';
+  }
+
   private static shouldFallbackTranslateToCpu(requestedDevice: string, error: unknown) {
     const normalized = this.normalizeRequestedDevice(requestedDevice, 'AUTO');
     if (normalized === 'CPU') return false;
@@ -2933,11 +2944,7 @@ export class OpenvinoRuntimeManager {
     const helperModelLoaded =
       Boolean(helperHealth?.modelLoaded) &&
       loadedModelPath === expectedModelPath &&
-      (
-        this.normalizeRequestedDevice(helperHealth?.device, requestedDevice) === requestedDevice ||
-        ((isQwenRuntime || isCohereRuntime) &&
-          this.normalizeRequestedDevice(helperHealth?.device, requestedDevice) === 'CPU')
-      ) &&
+      this.isAsrHelperDeviceCompatible(helperHealth?.device, requestedDevice, isQwenRuntime || isCohereRuntime) &&
       (!expectedRuntimeKind || String(helperHealth?.runtimeKind || '').trim().toLowerCase() === expectedRuntimeKind);
 
     if (helperModelLoaded) {

--- a/server/openvino_runtime_manager.ts
+++ b/server/openvino_runtime_manager.ts
@@ -259,6 +259,7 @@ class OpenVinoAsrHelperClient {
       windowsHide: true,
       env: {
         ...process.env,
+        ...PathManager.getRuntimeTempEnv(),
         PYTHONIOENCODING: 'utf-8',
       },
     });
@@ -524,6 +525,7 @@ class OpenVinoTranslateHelperClient {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: {
         ...process.env,
+        ...PathManager.getRuntimeTempEnv(),
         PYTHONIOENCODING: 'utf-8',
         PYTHONUTF8: '1',
       },
@@ -756,6 +758,7 @@ class OpenVinoGenaiTranslateHelperClient {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: {
         ...process.env,
+        ...PathManager.getRuntimeTempEnv(),
         NODE_NO_WARNINGS: process.env.NODE_NO_WARNINGS || '1',
       },
     });
@@ -1255,18 +1258,22 @@ export class OpenvinoRuntimeManager {
     modelPath: string;
     requestedDevice: string;
     cacheDir: string;
-    helperRuntimeKind: 'qwen3_asr_official' | 'ctc_asr' | null;
+    helperRuntimeKind: 'qwen3_asr_official' | 'ctc_asr' | 'cohere_openvino_asr' | 'cohere_transformers_asr' | null;
   }) {
     const requestedDevice = this.normalizeRequestedDevice(input.requestedDevice, 'AUTO');
     const loadTimeoutMs =
-      input.helperRuntimeKind === 'qwen3_asr_official' || input.helperRuntimeKind === 'ctc_asr'
+      input.helperRuntimeKind === 'qwen3_asr_official' ||
+        input.helperRuntimeKind === 'ctc_asr' ||
+        input.helperRuntimeKind === 'cohere_openvino_asr' ||
+        input.helperRuntimeKind === 'cohere_transformers_asr'
         ? this.getEnvNumber('OPENVINO_HELPER_HEAVY_LOAD_TIMEOUT_MS', 600000, 30000, 1800000)
         : this.getEnvNumber('OPENVINO_HELPER_LOAD_TIMEOUT_MS', 180000, 1000, 1800000);
     try {
-      await OpenVinoAsrHelperClient.loadModel(input.modelPath, requestedDevice, input.cacheDir, loadTimeoutMs);
+      const loaded = await OpenVinoAsrHelperClient.loadModel(input.modelPath, requestedDevice, input.cacheDir, loadTimeoutMs);
+      const effectiveDevice = this.normalizeRequestedDevice(loaded?.device, requestedDevice);
       return {
-        effectiveDevice: requestedDevice,
-        fallbackToCpu: false,
+        effectiveDevice,
+        fallbackToCpu: effectiveDevice === 'CPU' && !['CPU', 'AUTO'].includes(requestedDevice),
       };
     } catch (error) {
       const serializationCacheError =
@@ -1436,6 +1443,7 @@ export class OpenvinoRuntimeManager {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: {
         ...process.env,
+        ...PathManager.getRuntimeTempEnv(),
         NODE_NO_WARNINGS: process.env.NODE_NO_WARNINGS || '1',
       },
     });
@@ -2913,23 +2921,42 @@ export class OpenvinoRuntimeManager {
     const helperHealth = await OpenVinoAsrHelperClient.healthCheck(5000).catch(() => null);
     const expectedRuntimeKind = await this.detectHelperAsrRuntimeKind(input.modelPath);
     const isQwenRuntime = expectedRuntimeKind === 'qwen3_asr_official';
+    const isCohereRuntime =
+      expectedRuntimeKind === 'cohere_openvino_asr' || expectedRuntimeKind === 'cohere_transformers_asr';
+    const loadedRuntimeKind = String(helperHealth?.runtimeKind || '').trim().toLowerCase();
+    const expectedModelPath = path.resolve(input.modelPath).toLowerCase();
+    const loadedModelPath = helperHealth?.modelPath
+      ? path.resolve(String(helperHealth.modelPath)).toLowerCase()
+      : '';
     let effectiveDevice = requestedDevice;
     let fallbackToCpu = false;
     const helperModelLoaded =
       Boolean(helperHealth?.modelLoaded) &&
-      String(helperHealth?.modelPath || '').toLowerCase() === String(input.modelPath).toLowerCase() &&
+      loadedModelPath === expectedModelPath &&
       (
         this.normalizeRequestedDevice(helperHealth?.device, requestedDevice) === requestedDevice ||
-        (isQwenRuntime && this.normalizeRequestedDevice(helperHealth?.device, requestedDevice) === 'CPU')
+        ((isQwenRuntime || isCohereRuntime) &&
+          this.normalizeRequestedDevice(helperHealth?.device, requestedDevice) === 'CPU')
       ) &&
       (!expectedRuntimeKind || String(helperHealth?.runtimeKind || '').trim().toLowerCase() === expectedRuntimeKind);
 
     if (helperModelLoaded) {
       effectiveDevice = this.normalizeRequestedDevice(helperHealth?.device, requestedDevice);
-      fallbackToCpu = effectiveDevice === 'CPU' && requestedDevice !== 'CPU';
+      fallbackToCpu = effectiveDevice === 'CPU' && !['CPU', 'AUTO'].includes(requestedDevice);
     }
 
     if (!helperModelLoaded) {
+      const needsIsolatedTransformersRestart =
+        Boolean(helperHealth) &&
+        (
+          expectedRuntimeKind === 'cohere_openvino_asr' ||
+          expectedRuntimeKind === 'cohere_transformers_asr' ||
+          loadedRuntimeKind === 'cohere_openvino_asr' ||
+          loadedRuntimeKind === 'cohere_transformers_asr'
+        );
+      if (needsIsolatedTransformersRestart) {
+        OpenVinoAsrHelperClient.forceShutdownNow('Restarting ASR helper for isolated Cohere ASR runtime.');
+      }
       const loaded = await this.loadAsrHelperModelWithFallback({
         modelPath: input.modelPath,
         requestedDevice,
@@ -2967,6 +2994,10 @@ export class OpenvinoRuntimeManager {
           ? 'qwen3-asr-official-helper'
           : resolvedRuntimeKind === 'ctc_asr'
             ? 'ctc-asr-helper'
+            : resolvedRuntimeKind === 'cohere_openvino_asr'
+              ? 'cohere-openvino-asr-helper'
+            : resolvedRuntimeKind === 'cohere_transformers_asr'
+              ? 'cohere-transformers-asr-helper'
             : 'whisper-helper';
       const rawChunks = Array.isArray(resultPayload?.chunks) ? resultPayload.chunks : [];
       const normalizedWords = this.normalizeWhisperWordTimings(Array.isArray(resultPayload?.words) ? resultPayload.words : []);
@@ -3022,7 +3053,10 @@ export class OpenvinoRuntimeManager {
               asrTimeoutMaxMs: timeoutDecision.maxMs,
             },
             promptIgnored:
-              runtimeKind === 'qwen3_asr_official' || runtimeKind === 'ctc_asr'
+              runtimeKind === 'qwen3_asr_official' ||
+              runtimeKind === 'ctc_asr' ||
+              runtimeKind === 'cohere_openvino_asr' ||
+              runtimeKind === 'cohere_transformers_asr'
                 ? Boolean(String(input.prompt || '').trim())
                 : undefined,
           },
@@ -3092,7 +3126,10 @@ export class OpenvinoRuntimeManager {
             asrTimeoutMaxMs: timeoutDecision.maxMs,
           },
           promptIgnored:
-            runtimeKind === 'qwen3_asr_official' || runtimeKind === 'ctc_asr'
+            runtimeKind === 'qwen3_asr_official' ||
+            runtimeKind === 'ctc_asr' ||
+            runtimeKind === 'cohere_openvino_asr' ||
+            runtimeKind === 'cohere_transformers_asr'
               ? Boolean(String(input.prompt || '').trim())
               : undefined,
         },
@@ -3774,8 +3811,12 @@ export class OpenvinoRuntimeManager {
       normalizedRuntime !== 'openvino-whisper-node' ? await this.detectHelperAsrRuntimeKind(input.modelPath) : null;
     const shouldUseHelperRuntime =
       normalizedRuntime === 'openvino-ctc-asr' ||
+      normalizedRuntime === 'openvino-cohere-asr' ||
+      normalizedRuntime === 'hf-transformers-asr' ||
       detectedHelperRuntimeKind === 'qwen3_asr_official' ||
-      detectedHelperRuntimeKind === 'ctc_asr';
+      detectedHelperRuntimeKind === 'ctc_asr' ||
+      detectedHelperRuntimeKind === 'cohere_openvino_asr' ||
+      detectedHelperRuntimeKind === 'cohere_transformers_asr';
     if (shouldUseHelperRuntime) {
       return this.transcribeWithAsrHelper(input);
     }
@@ -4006,6 +4047,7 @@ export class OpenvinoRuntimeManager {
         windowsHide: true,
         env: {
           ...process.env,
+          ...PathManager.getRuntimeTempEnv(),
           PYTHONIOENCODING: 'utf-8',
         },
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -4069,6 +4111,12 @@ export class OpenvinoRuntimeManager {
     if (normalized === 'openvino-ctc-asr') {
       return 'openvino-ctc-asr';
     }
+    if (normalized === 'openvino-cohere-asr') {
+      return 'openvino-cohere-asr';
+    }
+    if (normalized === 'hf-transformers-asr') {
+      return 'hf-transformers-asr';
+    }
     if (normalized === 'openvino-whisper-node') {
       return 'openvino-whisper-node';
     }
@@ -4105,6 +4153,7 @@ export class OpenvinoRuntimeManager {
         windowsHide: true,
         env: {
           ...process.env,
+          ...PathManager.getRuntimeTempEnv(),
           PYTHONIOENCODING: 'utf-8',
           PYTHONUTF8: '1',
         },
@@ -4184,6 +4233,7 @@ export class OpenvinoRuntimeManager {
         windowsHide: true,
         env: {
           ...process.env,
+          ...PathManager.getRuntimeTempEnv(),
           PYTHONIOENCODING: 'utf-8',
           PYTHONUTF8: '1',
         },
@@ -4273,7 +4323,9 @@ export class OpenvinoRuntimeManager {
     return detailParts.length > 0 ? `\n${detailParts.join('\n\n')}` : '';
   }
 
-  private static async detectHelperAsrRuntimeKind(modelPath: string): Promise<'qwen3_asr_official' | 'ctc_asr' | null> {
+  private static async detectHelperAsrRuntimeKind(
+    modelPath: string
+  ): Promise<'qwen3_asr_official' | 'ctc_asr' | 'cohere_openvino_asr' | 'cohere_transformers_asr' | null> {
     const officialChecks = await Promise.all([
       fs.pathExists(path.join(modelPath, 'thinker', 'openvino_thinker_language_model.xml')),
       fs.pathExists(path.join(modelPath, 'thinker', 'openvino_thinker_audio_model.xml')),
@@ -4282,6 +4334,19 @@ export class OpenvinoRuntimeManager {
     ]);
     if (officialChecks.every(Boolean)) {
       return 'qwen3_asr_official';
+    }
+
+    const cohereOvChecks = await Promise.all([
+      fs.pathExists(path.join(modelPath, 'arcsub_cohere_asr_ov_config.json')),
+      fs.pathExists(path.join(modelPath, 'openvino_model.xml')),
+      fs.pathExists(path.join(modelPath, 'openvino_model.bin')),
+      fs.pathExists(path.join(modelPath, 'config.json')),
+      fs.pathExists(path.join(modelPath, 'preprocessor_config.json')),
+      fs.pathExists(path.join(modelPath, 'processor_config.json')),
+      fs.pathExists(path.join(modelPath, 'tokenizer_config.json')),
+    ]);
+    if (cohereOvChecks.every(Boolean)) {
+      return 'cohere_openvino_asr';
     }
 
     const ctcChecks = await Promise.all([
@@ -4296,6 +4361,20 @@ export class OpenvinoRuntimeManager {
       (await fs.pathExists(path.join(modelPath, 'vocab.txt')));
     if (ctcChecks.every(Boolean) && hasCtcTokenizer) {
       return 'ctc_asr';
+    }
+
+    const cohereChecks = await Promise.all([
+      fs.pathExists(path.join(modelPath, 'config.json')),
+      fs.pathExists(path.join(modelPath, 'preprocessor_config.json')),
+      fs.pathExists(path.join(modelPath, 'tokenizer_config.json')),
+      fs.pathExists(path.join(modelPath, 'model.safetensors')),
+      fs.pathExists(path.join(modelPath, 'configuration_cohere_asr.py')),
+      fs.pathExists(path.join(modelPath, 'modeling_cohere_asr.py')),
+      fs.pathExists(path.join(modelPath, 'processing_cohere_asr.py')),
+      fs.pathExists(path.join(modelPath, 'tokenization_cohere_asr.py')),
+    ]);
+    if (cohereChecks.every(Boolean)) {
+      return 'cohere_transformers_asr';
     }
 
     return null;
@@ -4341,6 +4420,7 @@ export class OpenvinoRuntimeManager {
         env: {
           ...process.env,
           ...(input.envOverrides || {}),
+          ...PathManager.getRuntimeTempEnv(),
           PYTHONIOENCODING: 'utf-8',
         },
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/server/path_manager.ts
+++ b/server/path_manager.ts
@@ -76,6 +76,32 @@ export class PathManager {
     return p;
   }
 
+  static getRuntimeTempEnv() {
+    const runtimePath = this.getRuntimePath();
+    const tmpPath = this.getTmpPath();
+    const huggingFaceCachePath = path.join(tmpPath, 'huggingface');
+    const pipCachePath = path.join(tmpPath, 'pip-cache');
+    const torchCachePath = path.join(tmpPath, 'torch-cache');
+    fs.ensureDirSync(huggingFaceCachePath);
+    fs.ensureDirSync(pipCachePath);
+    fs.ensureDirSync(torchCachePath);
+    return {
+      APP_RUNTIME_DIR: runtimePath,
+      APP_TMP_DIR: tmpPath,
+      ARCSUB_RUNTIME_DIR: runtimePath,
+      ARCSUB_RUNTIME_TMP_DIR: tmpPath,
+      HF_HOME: huggingFaceCachePath,
+      HF_HUB_CACHE: path.join(huggingFaceCachePath, 'hub'),
+      HF_XET_CACHE: path.join(huggingFaceCachePath, 'xet'),
+      HF_DATASETS_CACHE: path.join(huggingFaceCachePath, 'datasets'),
+      PIP_CACHE_DIR: pipCachePath,
+      TORCH_HOME: torchCachePath,
+      TMPDIR: tmpPath,
+      TEMP: tmpPath,
+      TMP: tmpPath,
+    };
+  }
+
   static getLocalPath() {
     const p = this.resolveConfiguredDir('APP_LOCAL_DIR', 'local');
     fs.ensureDirSync(p);

--- a/server/pyannote_diarization_service.ts
+++ b/server/pyannote_diarization_service.ts
@@ -173,6 +173,7 @@ export class PyannoteDiarizationService {
         cwd: workspaceRoot,
         env: {
           ...process.env,
+          ...PathManager.getRuntimeTempEnv(),
           PYTHONUTF8: '1',
           PYTHONIOENCODING: 'utf-8',
         },
@@ -295,6 +296,7 @@ export class PyannoteDiarizationService {
         cwd: workspaceRoot,
         env: {
           ...process.env,
+          ...PathManager.getRuntimeTempEnv(),
           PYTHONUTF8: '1',
           PYTHONIOENCODING: 'utf-8',
         },
@@ -324,6 +326,7 @@ export class PyannoteDiarizationService {
           cwd: workspaceRoot,
           env: {
             ...process.env,
+            ...PathManager.getRuntimeTempEnv(),
             PYTHONUTF8: '1',
             PYTHONIOENCODING: 'utf-8',
           },
@@ -355,6 +358,7 @@ export class PyannoteDiarizationService {
           cwd: workspaceRoot,
           env: {
             ...process.env,
+            ...PathManager.getRuntimeTempEnv(),
             PYTHONUTF8: '1',
             PYTHONIOENCODING: 'utf-8',
           },

--- a/server/services/asr_service.ts
+++ b/server/services/asr_service.ts
@@ -160,6 +160,21 @@ export class AsrService {
     }
   }
 
+  private static isQwen3AsrLocalModel(input: {
+    localModelId?: string | null;
+    localModelRuntime?: string | null;
+    localModelPath?: string | null;
+  }) {
+    const signature = [
+      input.localModelRuntime,
+      input.localModelId,
+      input.localModelPath,
+    ]
+      .map((value) => String(value || '').toLowerCase())
+      .join(' ');
+    return signature.includes('openvino-qwen3-asr') || signature.includes('qwen3-asr');
+  }
+
   private static getEnvNumber(name: string, fallback: number, min?: number, max?: number) {
     const raw = process.env[name];
     if (typeof raw !== 'string' || !raw.trim()) return fallback;
@@ -878,6 +893,11 @@ export class AsrService {
       if (!input.localModelId || !input.localModelPath) {
         throw new Error('Local ASR runtime is not configured.');
       }
+      const preferAlignmentFirstNoSpace = Boolean(input.options.wordAlignment) && !this.isQwen3AsrLocalModel({
+        localModelId: input.localModelId,
+        localModelRuntime: input.localModelRuntime,
+        localModelPath: input.localModelPath,
+      });
       return transcribeWithLocalAsrRuntime({
         filePath,
         localModelId: input.localModelId,
@@ -891,7 +911,7 @@ export class AsrService {
         extractStructuredTranscript: (transcript, transcriptLanguage, extractOptions = {}) =>
           this.extractStructuredTranscript(transcript, transcriptLanguage, {
             ...extractOptions,
-            preferAlignmentFirstNoSpace: Boolean(input.options.wordAlignment),
+            preferAlignmentFirstNoSpace,
           }),
         toFiniteNumber: this.toFiniteNumber.bind(this),
       });

--- a/server/services/local_asr/model_profiles.ts
+++ b/server/services/local_asr/model_profiles.ts
@@ -40,6 +40,22 @@ const LOCAL_ASR_MODEL_PROFILES: LocalAsrModelProfile[] = [
     repoIds: ['MediaTek-Research/Breeze-ASR-25'],
     notes: ['Breeze ASR 25 is fine-tuned from Whisper large-v2; uses the local Whisper OpenVINO runtime path.'],
   },
+  {
+    id: 'local-reazon-japanese-wav2vec2-large-rs35kh',
+    repoIds: ['reazon-research/japanese-wav2vec2-large-rs35kh'],
+    notes: [
+      'Japanese CTC ASR model fine-tuned on ReazonSpeech; uses the OpenVINO CTC ASR runtime path after export.',
+      'This is an ASR transcription model, not the default Japanese forced-alignment profile.',
+    ],
+  },
+  {
+    id: 'local-cohere-transcribe-03-2026',
+    repoIds: ['CohereLabs/cohere-transcribe-03-2026'],
+    notes: [
+      'Cohere Transcribe is a gated 2B ASR model with 14 supported languages; ArcSub exports it to a Cohere-specific OpenVINO INT8 runtime.',
+      'It requires an explicit source language and does not provide native timestamps or diarization.',
+    ],
+  },
 ];
 
 const MODEL_PROFILE_BY_REPO_ID = new Map<string, LocalAsrModelProfile>();

--- a/server/services/local_asr/runtime.ts
+++ b/server/services/local_asr/runtime.ts
@@ -6,11 +6,13 @@ import type { LocalAsrRuntimeInput } from './runtimes/shared.js';
 export async function transcribeWithLocalAsrRuntime(input: LocalAsrRuntimeInput) {
   const isQwen3AsrRuntime = input.localModelRuntime === 'openvino-qwen3-asr';
   const isCtcAsrRuntime = input.localModelRuntime === 'openvino-ctc-asr';
+  const isCohereAsrRuntime = input.localModelRuntime === 'openvino-cohere-asr';
+  const isHfTransformersAsrRuntime = input.localModelRuntime === 'hf-transformers-asr';
 
   if (isQwen3AsrRuntime) {
     return transcribeWithLocalQwen3AsrRuntime(input);
   }
-  if (isCtcAsrRuntime) {
+  if (isCtcAsrRuntime || isCohereAsrRuntime || isHfTransformersAsrRuntime) {
     return transcribeWithLocalCtcAsrRuntime(input);
   }
 

--- a/server/services/local_llm/openvino_official_baselines.ts
+++ b/server/services/local_llm/openvino_official_baselines.ts
@@ -15,6 +15,16 @@ const CUSTOM_REPO_SEEDS: RepoSeed[] = [
     runtimeFamily: 'openvino-whisper-node',
     taskFamily: 'asr',
   },
+  {
+    repoId: 'reazon-research/japanese-wav2vec2-large-rs35kh',
+    runtimeFamily: 'openvino-ctc-asr',
+    taskFamily: 'asr',
+  },
+  {
+    repoId: 'CohereLabs/cohere-transcribe-03-2026',
+    runtimeFamily: 'openvino-cohere-asr',
+    taskFamily: 'asr',
+  },
 ];
 
 const LLM_REPO_IDS = [
@@ -338,6 +348,24 @@ function createExactOrFamilyBaseline(seed: RepoSeed): LocalOpenvinoOfficialBasel
     };
   }
 
+  if (/reazon-research\/japanese-wav2vec2-large-rs35kh/i.test(normalized)) {
+    return {
+      ...base,
+      baselineConfidence: 'partial_public',
+      sourceLinks: buildModelLinks(seed.repoId, true, true),
+      officialAsr: {
+        task: 'transcribe',
+        returnTimestamps: false,
+        chunkLengthSec: 30,
+        samplingRate: 16000,
+      },
+      notes: [
+        'Reazon Japanese Wav2Vec2 RS35KH is a Transformers AutoModelForCTC ASR model for Japanese.',
+        'ArcSub exports it through the OpenVINO CTC ASR runtime path and treats it as a Japanese transcription model.',
+      ],
+    };
+  }
+
   if (/qwen\/qwen3-asr-/i.test(normalized)) {
     return {
       ...base,
@@ -351,6 +379,25 @@ function createExactOrFamilyBaseline(seed: RepoSeed): LocalOpenvinoOfficialBasel
       notes: [
         'Qwen3-ASR fallback baseline: runtime family is inferred from ArcSub local integration.',
         'Verify helper/runtime-specific generation details when this model is first tuned.',
+      ],
+    };
+  }
+
+  if (/coherelabs\/cohere-transcribe-03-2026/i.test(normalized)) {
+    return {
+      ...base,
+      runtimeFamily: 'openvino-cohere-asr',
+      baselineConfidence: 'gated_partial',
+      officialAsr: {
+        task: 'transcribe',
+        returnTimestamps: false,
+        chunkLengthSec: 30,
+        samplingRate: 16000,
+      },
+      sourceLinks: buildModelLinks(seed.repoId, true, true),
+      notes: [
+        'Cohere Transcribe 03 2026 is a gated ASR model that ArcSub converts into a Cohere-specific OpenVINO INT8 runtime.',
+        'It requires an explicit source language, does not provide native timestamps/diarization, and benefits from VAD before transcription.',
       ],
     };
   }
@@ -373,6 +420,7 @@ function inferFallbackTaskFamily(repoId: string): TaskFamily {
 function inferFallbackRuntimeFamily(repoId: string): RuntimeFamily {
   const normalized = normalizeRepoId(repoId);
   if (/qwen\/qwen3-asr-/.test(normalized)) return 'openvino-qwen3-asr';
+  if (/coherelabs\/cohere-transcribe-03-2026/.test(normalized)) return 'openvino-cohere-asr';
   if (/wav2vec2|hubert|wavlm|unispeech|sew|data2vec-audio/.test(normalized)) return 'openvino-ctc-asr';
   if (/(^|\/)(flan-|mt5|umt5|t5|bart|mbart|marian|pegasus|m2m100|m2m_100|fsmt|prophetnet)/.test(normalized)) {
     return 'openvino-seq2seq-translate';

--- a/server/services/local_llm/profiles.ts
+++ b/server/services/local_llm/profiles.ts
@@ -9,6 +9,8 @@ function inferProfileFamily(localModel: LocalModelDefinition) {
     if (localModel.runtime === 'openvino-whisper-node') return 'whisper';
     if (localModel.runtime === 'openvino-ctc-asr') return 'ctc_asr';
     if (localModel.runtime === 'openvino-qwen3-asr') return 'qwen3_asr';
+    if (localModel.runtime === 'openvino-cohere-asr') return 'cohere_asr';
+    if (localModel.runtime === 'hf-transformers-asr') return 'hf_transformers_asr';
     if (repoId.includes('whisper')) return 'whisper';
     if (repoId.includes('qwen3-asr')) return 'qwen3_asr';
     return 'local-asr';

--- a/server/services/local_llm/translategemma.ts
+++ b/server/services/local_llm/translategemma.ts
@@ -33,13 +33,13 @@ function toTranslateGemmaLanguageCode(language?: string): string | null {
     uk: 'uk',
     vi: 'vi',
     zh: 'zh',
-    'zh-cn': 'zh-CN',
-    'zh-hans': 'zh-CN',
-    'zh-sg': 'zh-CN',
+    'zh-cn': 'zh-Hans',
+    'zh-hans': 'zh-Hans',
+    'zh-sg': 'zh-Hans-SG',
     'zh-tw': 'zh-TW',
-    'zh-hant': 'zh-TW',
-    'zh-hk': 'zh-TW',
-    'zh-mo': 'zh-TW',
+    'zh-hant': 'zh-Hant',
+    'zh-hk': 'zh-Hant-HK',
+    'zh-mo': 'zh-Hant-MO',
   };
 
   if (exactMap[normalized]) return exactMap[normalized];

--- a/server/services/local_llm/types.ts
+++ b/server/services/local_llm/types.ts
@@ -57,7 +57,9 @@ export interface LocalOpenvinoOfficialBaseline {
     | 'openvino-seq2seq-translate'
     | 'openvino-whisper-node'
     | 'openvino-ctc-asr'
-    | 'openvino-qwen3-asr';
+    | 'openvino-qwen3-asr'
+    | 'openvino-cohere-asr'
+    | 'hf-transformers-asr';
   taskFamily: 'translate' | 'asr' | 'vlm';
   baselineConfidence: LocalOpenvinoBaselineConfidence;
   sourceLinks: string[];

--- a/server/services/local_model_service.ts
+++ b/server/services/local_model_service.ts
@@ -1312,7 +1312,7 @@ export class LocalModelService {
       if (asrModels.some((model: any) => model?.id === local.id)) continue;
       asrModels.push({
         id: local.id,
-        name: `${local.displayName} (OpenVINO Local)`,
+        name: `${local.displayName} (Local)`,
         url: 'local://openvino/asr',
         key: '',
         model: local.repoId,

--- a/server/services/resource_manager.ts
+++ b/server/services/resource_manager.ts
@@ -6,15 +6,47 @@ import unzipper from 'unzipper';
 import { pipeline } from 'stream/promises';
 import { getBundledToolPath, isCommandAvailable } from '../runtime_tools.js';
 
+interface BaselineAssetDefinition {
+  id: string;
+  targetRelativePath: string;
+  sourceUrl: string;
+  category: string;
+}
+
+export interface BaselineAssetEnsureResult {
+  id: string;
+  category: string;
+  path: string;
+  sourceUrl: string;
+  installed: boolean;
+  skipped: boolean;
+  ready: boolean;
+}
+
 export class ResourceManager {
   private static HF_BASE = 'https://huggingface.co';
   private static readonly ENSURE_TOOLS_FAILURE_COOLDOWN_MS = 120_000;
   private static readonly DOWNLOAD_MAX_REDIRECTS = 5;
   private static readonly DOWNLOAD_MAX_RETRIES = 3;
   private static readonly DOWNLOAD_TIMEOUT_MS = 45_000;
+  private static readonly DEFAULT_REQUIRED_ASSETS = [
+    {
+      id: 'silero-vad',
+      targetRelativePath: 'silero_vad.onnx',
+      sourceUrl: 'https://huggingface.co/onnx-community/silero-vad/resolve/main/onnx/model.onnx?download=true',
+      category: 'vad',
+    },
+    {
+      id: 'ecapa-tdnn',
+      targetRelativePath: 'ecapa-tdnn.onnx',
+      sourceUrl: 'https://huggingface.co/AXERA-TECH/3D-Speaker/resolve/main/ecapa-tdnn.onnx?download=true',
+      category: 'speaker_embedding',
+    },
+  ];
   private static deployManifestCache: any | null = null;
   private static ensureToolsTask: Promise<void> | null = null;
   private static ensureToolsFailure: { message: string; until: number } | null = null;
+  private static baselineAssetTasks = new Map<string, Promise<BaselineAssetEnsureResult>>();
 
   private static async getDeployManifest() {
     if (this.deployManifestCache) return this.deployManifestCache;
@@ -23,6 +55,98 @@ export class ResourceManager {
       ? await fs.readJson(manifestPath).catch(() => null)
       : null;
     return this.deployManifestCache;
+  }
+
+  private static async getRequiredBaselineAssets(manifestOverride?: any) {
+    const manifest = manifestOverride ?? (await this.getDeployManifest());
+    const manifestAssets = Array.isArray(manifest?.assets?.required) ? manifest.assets.required : [];
+    const byId = new Map<string, BaselineAssetDefinition>();
+
+    for (const rawAsset of [...this.DEFAULT_REQUIRED_ASSETS, ...manifestAssets]) {
+      const id = String(rawAsset?.id || '').trim();
+      const targetRelativePath = String(rawAsset?.targetRelativePath || '').trim();
+      const sourceUrl = String(rawAsset?.sourceUrl || '').trim();
+      const category = String(rawAsset?.category || '').trim();
+      if (!id || !targetRelativePath || !sourceUrl || !category) continue;
+      byId.set(id, { id, targetRelativePath, sourceUrl, category });
+    }
+
+    return [...byId.values()];
+  }
+
+  private static async getRequiredBaselineAsset(identifier: string) {
+    const normalized = String(identifier || '').trim();
+    const assets = await this.getRequiredBaselineAssets();
+    const asset = assets.find(
+      (candidate) =>
+        candidate.id === normalized ||
+        candidate.category === normalized ||
+        candidate.targetRelativePath === normalized
+    );
+    if (!asset) {
+      throw new Error(`Unknown baseline asset: ${identifier}`);
+    }
+    return asset;
+  }
+
+  static async ensureBaselineAsset(identifier: string): Promise<BaselineAssetEnsureResult> {
+    const asset = await this.getRequiredBaselineAsset(identifier);
+    const destination = path.join(PathManager.getModelsPath(), asset.targetRelativePath);
+
+    if (await fs.pathExists(destination)) {
+      return {
+        id: asset.id,
+        category: asset.category,
+        path: destination,
+        sourceUrl: asset.sourceUrl,
+        installed: false,
+        skipped: true,
+        ready: true,
+      };
+    }
+
+    const existingTask = this.baselineAssetTasks.get(asset.id);
+    if (existingTask) return existingTask;
+
+    const task = (async () => {
+      console.log(`[ResourceManager] Downloading baseline asset ${asset.id} -> ${destination}`);
+      await this.downloadWithRedirect(asset.sourceUrl, destination);
+      return {
+        id: asset.id,
+        category: asset.category,
+        path: destination,
+        sourceUrl: asset.sourceUrl,
+        installed: true,
+        skipped: false,
+        ready: true,
+      };
+    })()
+      .catch(async (error: any) => {
+        await fs.remove(`${destination}.part`).catch(() => {});
+        throw error;
+      })
+      .finally(() => {
+        this.baselineAssetTasks.delete(asset.id);
+      });
+
+    this.baselineAssetTasks.set(asset.id, task);
+    return task;
+  }
+
+  static async ensureRequiredBaselineAssets(manifestOverride?: any) {
+    const installed: Array<{ id: string; path: string }> = [];
+    const skipped: Array<{ id: string; path: string }> = [];
+
+    for (const asset of await this.getRequiredBaselineAssets(manifestOverride)) {
+      const result = await this.ensureBaselineAsset(asset.id);
+      if (result.installed) {
+        installed.push({ id: result.id, path: result.path });
+      } else {
+        skipped.push({ id: result.id, path: result.path });
+      }
+    }
+
+    return { installed, skipped };
   }
 
   static async ensureTools() {

--- a/server/services/resource_manager.ts
+++ b/server/services/resource_manager.ts
@@ -74,9 +74,9 @@ export class ResourceManager {
     return [...byId.values()];
   }
 
-  private static async getRequiredBaselineAsset(identifier: string) {
+  private static async getRequiredBaselineAsset(identifier: string, manifestOverride?: any) {
     const normalized = String(identifier || '').trim();
-    const assets = await this.getRequiredBaselineAssets();
+    const assets = await this.getRequiredBaselineAssets(manifestOverride);
     const asset = assets.find(
       (candidate) =>
         candidate.id === normalized ||
@@ -89,8 +89,8 @@ export class ResourceManager {
     return asset;
   }
 
-  static async ensureBaselineAsset(identifier: string): Promise<BaselineAssetEnsureResult> {
-    const asset = await this.getRequiredBaselineAsset(identifier);
+  static async ensureBaselineAsset(identifier: string, manifestOverride?: any): Promise<BaselineAssetEnsureResult> {
+    const asset = await this.getRequiredBaselineAsset(identifier, manifestOverride);
     const destination = path.join(PathManager.getModelsPath(), asset.targetRelativePath);
 
     if (await fs.pathExists(destination)) {
@@ -105,7 +105,8 @@ export class ResourceManager {
       };
     }
 
-    const existingTask = this.baselineAssetTasks.get(asset.id);
+    const taskKey = `${asset.id}:${asset.targetRelativePath}:${asset.sourceUrl}`;
+    const existingTask = this.baselineAssetTasks.get(taskKey);
     if (existingTask) return existingTask;
 
     const task = (async () => {
@@ -126,10 +127,10 @@ export class ResourceManager {
         throw error;
       })
       .finally(() => {
-        this.baselineAssetTasks.delete(asset.id);
+        this.baselineAssetTasks.delete(taskKey);
       });
 
-    this.baselineAssetTasks.set(asset.id, task);
+    this.baselineAssetTasks.set(taskKey, task);
     return task;
   }
 
@@ -138,7 +139,7 @@ export class ResourceManager {
     const skipped: Array<{ id: string; path: string }> = [];
 
     for (const asset of await this.getRequiredBaselineAssets(manifestOverride)) {
-      const result = await this.ensureBaselineAsset(asset.id);
+      const result = await this.ensureBaselineAsset(asset.id, manifestOverride);
       if (result.installed) {
         installed.push({ id: result.id, path: result.path });
       } else {

--- a/server/services/runtime_readiness_service.ts
+++ b/server/services/runtime_readiness_service.ts
@@ -226,6 +226,7 @@ function inspectPythonCommand(candidate: PythonCommandCandidate) {
     encoding: 'utf8',
     env: {
       ...process.env,
+      ...PathManager.getRuntimeTempEnv(),
       PYTHONUTF8: '1',
       PYTHONIOENCODING: 'utf-8',
     },

--- a/server/services/system_monitor.ts
+++ b/server/services/system_monitor.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { PathManager } from '../path_manager.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -208,7 +209,7 @@ async function readWindowsIntelDxdiagEntries() {
     return windowsDxdiagCached;
   }
 
-  const tmpPath = path.join(os.tmpdir(), `arcsub-dxdiag-${process.pid}-${Date.now()}.txt`);
+  const tmpPath = path.join(PathManager.getTmpPath(), `arcsub-dxdiag-${process.pid}-${Date.now()}.txt`);
   try {
     await execFileAsync('dxdiag', ['/t', tmpPath], { windowsHide: true });
     const text = await fs.readFile(tmpPath, 'utf8');

--- a/server/speaker_embedding_service.ts
+++ b/server/speaker_embedding_service.ts
@@ -3,6 +3,7 @@ import fs from "fs-extra";
 import { PathManager } from "./path_manager.js";
 import { AudioProcessor } from "./audio_processor.js";
 import { OpenvinoBackend } from "./openvino_backend.js";
+import { ResourceManager } from "./services/resource_manager.js";
 
 export class SpeakerEmbeddingService {
   private static compiledModel: any | null = null;
@@ -14,6 +15,15 @@ export class SpeakerEmbeddingService {
    */
   static async init() {
     if (this.compiledModel) return;
+    if (!(await fs.pathExists(this.modelPath))) {
+      try {
+        await ResourceManager.ensureBaselineAsset("speaker_embedding");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`[Embedding] Could not download speaker embedding model, continuing with existing fallback behavior: ${message}`);
+      }
+    }
+
     if (!(await fs.pathExists(this.modelPath))) {
       throw new Error(`[Embedding] model not found: ${this.modelPath}`);
     }

--- a/server/vad_service.ts
+++ b/server/vad_service.ts
@@ -5,6 +5,7 @@ import fs from "fs-extra";
 import { PathManager } from "./path_manager.js";
 import { OpenvinoBackend } from "./openvino_backend.js";
 import { resolveToolCommand } from "./runtime_tools.js";
+import { ResourceManager } from "./services/resource_manager.js";
 
 export interface SpeechSegment {
   start: number;
@@ -429,11 +430,21 @@ export class VadService {
 
   static async init() {
     if (this.compiledModel || this.session) return;
-    if (!(await fs.pathExists(this.modelPath))) {
+    let openvinoModelPath = await this.getOpenvinoModelPath();
+    if (!openvinoModelPath && !(await fs.pathExists(this.modelPath))) {
+      try {
+        await ResourceManager.ensureBaselineAsset("vad");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`[VAD] Could not download baseline VAD model, continuing with existing fallback behavior: ${message}`);
+      }
+      openvinoModelPath = await this.getOpenvinoModelPath();
+    }
+
+    if (!openvinoModelPath && !(await fs.pathExists(this.modelPath))) {
       throw new Error(`[VAD] model not found: ${this.modelPath}`);
     }
 
-    const openvinoModelPath = await this.getOpenvinoModelPath();
     let openvinoError: unknown = null;
     if (openvinoModelPath) {
       try {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -80,11 +80,14 @@ interface LocalModelEntry {
     | 'optimum-export-openvino'
     | 'openvino-ctc-asr-export'
     | 'openvino-qwen3-asr-export'
+    | 'openvino-cohere-asr-export'
     | 'unsupported';
   runtimeLayout?:
     | 'asr-whisper'
     | 'asr-ctc'
     | 'asr-qwen3-official'
+    | 'asr-cohere-ov'
+    | 'asr-hf-transformers'
     | 'translate-llm'
     | 'translate-seq2seq'
     | 'translate-vlm';
@@ -92,8 +95,10 @@ interface LocalModelEntry {
     | 'openvino-whisper-node'
     | 'openvino-ctc-asr'
     | 'openvino-qwen3-asr'
-      | 'openvino-seq2seq-translate'
-      | 'openvino-llm-node';
+    | 'openvino-cohere-asr'
+    | 'hf-transformers-asr'
+    | 'openvino-seq2seq-translate'
+    | 'openvino-llm-node';
   runtimeHints?: LocalModelRuntimeHints;
   selected: boolean;
   installError?: string | null;
@@ -660,6 +665,9 @@ function formatLocalModelConversionMethod(language: Language, value?: LocalModel
   if (normalized === 'openvino-qwen3-asr-export') {
     return 'Qwen3-ASR Export';
   }
+  if (normalized === 'openvino-cohere-asr-export') {
+    return 'Cohere ASR Export';
+  }
   return normalized ? normalized : 'Unknown';
 }
 
@@ -668,6 +676,8 @@ function formatLocalModelRuntimeLayout(language: Language, value?: LocalModelEnt
   if (normalized === 'asr-whisper') return 'ASR / Whisper';
   if (normalized === 'asr-ctc') return 'ASR / CTC';
   if (normalized === 'asr-qwen3-official') return 'ASR / Qwen3 Official';
+  if (normalized === 'asr-cohere-ov') return 'ASR / Cohere OV';
+  if (normalized === 'asr-hf-transformers') return 'ASR / HF Transformers';
   if (normalized === 'translate-llm') return 'Translate / LLM';
   if (normalized === 'translate-seq2seq') return 'Translate / Seq2Seq';
   if (normalized === 'translate-vlm') return 'Translate / VLM';
@@ -679,6 +689,8 @@ function formatLocalModelRuntimeEngine(value?: LocalModelEntry['runtime']) {
   if (normalized === 'openvino-whisper-node') return 'OpenVINO Whisper';
   if (normalized === 'openvino-ctc-asr') return 'OpenVINO CTC-ASR';
   if (normalized === 'openvino-qwen3-asr') return 'OpenVINO Qwen3-ASR';
+  if (normalized === 'openvino-cohere-asr') return 'OpenVINO Cohere ASR';
+  if (normalized === 'hf-transformers-asr') return 'HF Transformers ASR';
   if (normalized === 'openvino-seq2seq-translate') return 'OpenVINO Seq2Seq';
   if (normalized === 'openvino-llm-node') return 'OpenVINO LLM';
   return normalized ? normalized : 'Unknown';

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,12 +106,16 @@ export interface LocalModelSelection {
       | 'openvino-whisper-node'
       | 'openvino-ctc-asr'
       | 'openvino-qwen3-asr'
+      | 'openvino-cohere-asr'
+      | 'hf-transformers-asr'
       | 'openvino-seq2seq-translate'
       | 'openvino-llm-node';
     runtimeLayout?:
       | 'asr-whisper'
       | 'asr-ctc'
       | 'asr-qwen3-official'
+      | 'asr-cohere-ov'
+      | 'asr-hf-transformers'
       | 'translate-llm'
       | 'translate-seq2seq'
       | 'translate-vlm';
@@ -133,6 +137,7 @@ export interface LocalModelSelection {
       | 'optimum-export-openvino'
       | 'openvino-ctc-asr-export'
       | 'openvino-qwen3-asr-export'
+      | 'openvino-cohere-asr-export'
       | 'unsupported';
     device: 'AUTO';
     source: 'builtin' | 'custom';

--- a/start.ps1
+++ b/start.ps1
@@ -90,7 +90,7 @@ function Resolve-LogsDir([string]$WorkspaceRoot) {
   return Join-Path (Join-Path $WorkspaceRoot $runtimeDir) "logs"
 }
 
-function Kill-ProcessTree([int]$ProcessId) {
+function Stop-ProcessTree([int]$ProcessId) {
   if ($ProcessId -le 0) { return }
   if ($DryRun) {
     Write-Info "DryRun: would kill PID $ProcessId"
@@ -159,7 +159,7 @@ try {
   if ($killPids.Count -gt 0) {
     Write-Step "Stopping stale processes: $($killPids -join ', ')"
     foreach ($procId in $killPids) {
-      Kill-ProcessTree -ProcessId $procId
+      Stop-ProcessTree -ProcessId $procId
     }
     if (-not $DryRun) {
       Start-Sleep -Milliseconds 800

--- a/start.ps1
+++ b/start.ps1
@@ -23,6 +23,39 @@ function Write-Info($message) {
   Write-Host "[ArcSub] $message" -ForegroundColor Gray
 }
 
+function Start-BrowserLauncher([string]$Url, [switch]$Disabled) {
+  if ($Disabled) { return }
+
+  $launcherScript = @'
+param([string]$Url)
+$ErrorActionPreference = "SilentlyContinue"
+$deadline = (Get-Date).AddMinutes(2)
+while ((Get-Date) -lt $deadline) {
+  try {
+    $response = Invoke-WebRequest -UseBasicParsing -Uri ($Url.TrimEnd('/') + "/api/runtime/readiness") -TimeoutSec 5
+    if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+      Start-Process $Url | Out-Null
+      exit 0
+    }
+  } catch {
+  }
+  Start-Sleep -Seconds 2
+}
+exit 0
+'@
+
+  Start-Job -ScriptBlock {
+    param($scriptText, $targetUrl)
+    $tempPath = Join-Path ([System.IO.Path]::GetTempPath()) ("arcsub-dev-open-browser-" + [Guid]::NewGuid().ToString("N") + ".ps1")
+    [System.IO.File]::WriteAllText($tempPath, $scriptText, [System.Text.UTF8Encoding]::new($false))
+    try {
+      & powershell -ExecutionPolicy Bypass -File $tempPath -Url $targetUrl | Out-Null
+    } finally {
+      Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+    }
+  } -ArgumentList $launcherScript, $Url | Out-Null
+}
+
 function Get-DotEnvValue([string]$Key, [string]$Default = "") {
   $envPath = Join-Path $scriptPath ".env"
   if (-not (Test-Path $envPath)) { return $Default }
@@ -140,8 +173,10 @@ try {
     exit 0
   }
 
+  $browserUrl = "http://127.0.0.1:3000"
+  Start-BrowserLauncher -Url $browserUrl -Disabled:$NoBrowser
   if (-not $NoBrowser) {
-    Start-Process "http://127.0.0.1:3000" | Out-Null
+    Write-Info "Browser will open after dev server is ready: $browserUrl"
   }
 
   $logsDir = Resolve-LogsDir -WorkspaceRoot $scriptPath
@@ -154,7 +189,7 @@ try {
 
   Write-Step "Starting dev server (npm run dev)..."
   Write-Info "Dev log: $logPath"
-  npm run dev 2>&1 | Tee-Object -FilePath $logPath
+  cmd /d /s /c "npm run dev < NUL" 2>&1 | Tee-Object -FilePath $logPath
   if ($LASTEXITCODE -ne 0) {
     throw "Dev server exited with code $LASTEXITCODE. Check log: $logPath"
   }

--- a/tools_src/convert_hf_model_to_openvino.py
+++ b/tools_src/convert_hf_model_to_openvino.py
@@ -13,12 +13,61 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import traceback
 from typing import Iterable
 
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
+
+
+def _resolve_workspace_path(raw_path: str | None, fallback: pathlib.Path) -> pathlib.Path:
+    value = str(raw_path or "").strip()
+    if not value:
+        return fallback.resolve()
+    candidate = pathlib.Path(value)
+    if not candidate.is_absolute():
+        candidate = SCRIPT_DIR.parent / candidate
+    return candidate.resolve()
+
+
+def _resolve_runtime_root() -> pathlib.Path:
+    return _resolve_workspace_path(
+        os.environ.get("ARCSUB_RUNTIME_DIR") or os.environ.get("APP_RUNTIME_DIR"),
+        SCRIPT_DIR.parent / "runtime",
+    )
+
+
+def _resolve_runtime_tmp_root() -> pathlib.Path:
+    root = _resolve_workspace_path(
+        os.environ.get("ARCSUB_RUNTIME_TMP_DIR") or os.environ.get("APP_TMP_DIR"),
+        _resolve_runtime_root() / "tmp",
+    )
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+RUNTIME_TMP_ROOT = _resolve_runtime_tmp_root()
+CONVERTER_TMP_ROOT = RUNTIME_TMP_ROOT / "openvino-convert"
+HF_CACHE_ROOT = RUNTIME_TMP_ROOT / "huggingface"
+PIP_CACHE_ROOT = RUNTIME_TMP_ROOT / "pip-cache"
+TORCH_CACHE_ROOT = RUNTIME_TMP_ROOT / "torch-cache"
+CONVERTER_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+HF_CACHE_ROOT.mkdir(parents=True, exist_ok=True)
+PIP_CACHE_ROOT.mkdir(parents=True, exist_ok=True)
+TORCH_CACHE_ROOT.mkdir(parents=True, exist_ok=True)
+for env_key in ("TMPDIR", "TEMP", "TMP"):
+    os.environ[env_key] = str(RUNTIME_TMP_ROOT)
+os.environ["ARCSUB_RUNTIME_TMP_DIR"] = str(RUNTIME_TMP_ROOT)
+os.environ["APP_TMP_DIR"] = str(RUNTIME_TMP_ROOT)
+os.environ["HF_HOME"] = str(HF_CACHE_ROOT)
+os.environ["HF_HUB_CACHE"] = str(HF_CACHE_ROOT / "hub")
+os.environ["HF_XET_CACHE"] = str(HF_CACHE_ROOT / "xet")
+os.environ["HF_DATASETS_CACHE"] = str(HF_CACHE_ROOT / "datasets")
+os.environ["PIP_CACHE_DIR"] = str(PIP_CACHE_ROOT)
+os.environ["TORCH_HOME"] = str(TORCH_CACHE_ROOT)
+tempfile.tempdir = str(RUNTIME_TMP_ROOT)
 
 from openvino_asr_env import prepare_openvino_env
 from python_runtime_bootstrap import ensure_python_packages
@@ -53,6 +102,8 @@ COPY_METADATA_FILES = [
     "config.json",
     "generation_config.json",
     "preprocessor_config.json",
+    "processor_config.json",
+    "tokenizer.model",
     "tokenizer.json",
     "tokenizer_config.json",
     "special_tokens_map.json",
@@ -108,6 +159,8 @@ ENCODER_DECODER_OV_XML_FILES = [
     "openvino_decoder_model.xml",
     "openvino_decoder_with_past_model.xml",
 ]
+
+COHERE_ASR_OV_MARKER_FILE = "arcsub_cohere_asr_ov_config.json"
 
 
 def _bool_env(name: str, default: bool = False) -> bool:
@@ -188,8 +241,7 @@ def _copy_repo_metadata(snapshot_dir: pathlib.Path, output_dir: pathlib.Path) ->
     for relative_name in _pick_existing(available, COPY_METADATA_FILES):
         source_path = snapshot_dir / relative_name
         target_path = output_dir / relative_name
-        target_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source_path, target_path)
+        _copy_file_with_retry(source_path, target_path)
         copied.append(relative_name)
     return copied
 
@@ -206,22 +258,82 @@ def _compress_to_int8(model: ov.Model) -> ov.Model:
     return compress_weights(model)
 
 
+def _retry_file_operation(operation_name: str, callback, *, missing_ok: bool = False):
+    attempts = max(1, int(os.environ.get("OPENVINO_HF_CONVERTER_FILE_RETRY_ATTEMPTS", "24") or "24"))
+    delay_sec = max(0.05, float(os.environ.get("OPENVINO_HF_CONVERTER_FILE_RETRY_DELAY_SEC", "0.25") or "0.25"))
+    last_error: BaseException | None = None
+
+    for attempt in range(attempts):
+        try:
+            return callback()
+        except FileNotFoundError as error:
+            if missing_ok:
+                return None
+            raise error
+        except PermissionError as error:
+            last_error = error
+        except OSError as error:
+            if getattr(error, "winerror", None) not in (32, 33):
+                raise
+            last_error = error
+
+        gc.collect()
+        if attempt + 1 < attempts:
+            time.sleep(delay_sec * min(4, attempt + 1))
+
+    raise RuntimeError(f"{operation_name} failed after {attempts} attempts: {last_error}") from last_error
+
+
+def _replace_file_with_retry(source_path: pathlib.Path, target_path: pathlib.Path) -> None:
+    def replace() -> None:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.replace(target_path)
+
+    _retry_file_operation(f"Replacing {target_path}", replace)
+
+
+def _copy_file_with_retry(source_path: pathlib.Path, target_path: pathlib.Path) -> None:
+    def copy() -> None:
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, target_path)
+
+    _retry_file_operation(f"Copying {source_path} to {target_path}", copy)
+
+
+def _remove_tree_with_retry(path_obj: pathlib.Path) -> None:
+    if not path_obj.exists():
+        return
+
+    def remove() -> None:
+        shutil.rmtree(path_obj)
+
+    _retry_file_operation(f"Removing {path_obj}", remove, missing_ok=True)
+
+
+def _temporary_directory(prefix: str):
+    CONVERTER_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+    return tempfile.TemporaryDirectory(
+        prefix=prefix,
+        dir=str(CONVERTER_TMP_ROOT),
+        ignore_cleanup_errors=True,
+    )
+
+
 def _save_model_preserve_precision(model: ov.Model, xml_path: pathlib.Path) -> None:
     _save_ov_model(model, xml_path)
 
 
 def _save_ov_model(model: ov.Model, xml_path: pathlib.Path) -> None:
     xml_path.parent.mkdir(parents=True, exist_ok=True)
-    temp_xml = xml_path.with_name(f"{xml_path.stem}.tmp.xml")
-    temp_bin = temp_xml.with_suffix(".bin")
     final_bin = xml_path.with_suffix(".bin")
-    temp_xml.unlink(missing_ok=True)
-    temp_bin.unlink(missing_ok=True)
-    ov.save_model(model, str(temp_xml), compress_to_fp16=False)
-    xml_path.unlink(missing_ok=True)
-    final_bin.unlink(missing_ok=True)
-    shutil.move(temp_xml, xml_path)
-    shutil.move(temp_bin, final_bin)
+    with _temporary_directory(f"{xml_path.stem}-save-") as temp_dir:
+        temp_xml = pathlib.Path(temp_dir) / xml_path.name
+        temp_bin = temp_xml.with_suffix(".bin")
+        ov.save_model(model, str(temp_xml), compress_to_fp16=False)
+        gc.collect()
+
+        _replace_file_with_retry(temp_bin, final_bin)
+        _replace_file_with_retry(temp_xml, xml_path)
 
 
 def _compress_exported_ov_files(output_dir: pathlib.Path, xml_names: Iterable[str]) -> list[str]:
@@ -230,23 +342,24 @@ def _compress_exported_ov_files(output_dir: pathlib.Path, xml_names: Iterable[st
         xml_path = output_dir / xml_name
         if not xml_path.exists():
             continue
-        source_model = ov.Core().read_model(str(xml_path))
-        compressed_model = _compress_to_int8(source_model)
-        del source_model
+        bin_path = xml_path.with_suffix(".bin")
+        if not bin_path.exists():
+            raise RuntimeError(f"Cannot compress OpenVINO IR without matching bin file: {bin_path}")
 
-        temp_xml = xml_path.with_name(f"{xml_path.stem}.compressed.xml")
-        temp_bin = temp_xml.with_suffix(".bin")
-        final_bin = xml_path.with_suffix(".bin")
-        temp_xml.unlink(missing_ok=True)
-        temp_bin.unlink(missing_ok=True)
-        ov.save_model(compressed_model, str(temp_xml), compress_to_fp16=False)
-        del compressed_model
-        gc.collect()
+        with _temporary_directory(f"{xml_path.stem}-compress-") as temp_dir:
+            source_xml = pathlib.Path(temp_dir) / xml_path.name
+            source_bin = source_xml.with_suffix(".bin")
+            _copy_file_with_retry(xml_path, source_xml)
+            _copy_file_with_retry(bin_path, source_bin)
 
-        xml_path.unlink(missing_ok=True)
-        final_bin.unlink(missing_ok=True)
-        shutil.move(temp_xml, xml_path)
-        shutil.move(temp_bin, final_bin)
+            source_model = ov.Core().read_model(str(source_xml))
+            compressed_model = _compress_to_int8(source_model)
+            del source_model
+            gc.collect()
+
+            _save_ov_model(compressed_model, xml_path)
+            del compressed_model
+            gc.collect()
         compressed.append(xml_name)
     return compressed
 
@@ -504,32 +617,47 @@ def _export_ctc_asr_with_ovmodel(
     from optimum.intel import OVModelForCTC  # type: ignore
 
     token = _resolve_hf_token()
-    model = OVModelForCTC.from_pretrained(
-        repo_id,
-        export=True,
-        compile=False,
-        trust_remote_code=trust_remote_code,
-        token=token,
-        from_tf=from_tf,
-    )
-    model.save_pretrained(output_dir)
+    with _temporary_directory("arcsub-ov-ctc-export-") as export_tmp_dir:
+        export_dir = pathlib.Path(export_tmp_dir)
+        model = OVModelForCTC.from_pretrained(
+            repo_id,
+            export=True,
+            compile=False,
+            trust_remote_code=trust_remote_code,
+            token=token,
+            from_tf=from_tf,
+        )
+        model.save_pretrained(export_dir)
+        model = None
+        gc.collect()
 
-    processor_info = _save_ctc_processor_bundle(
-        repo_id,
-        output_dir,
-        trust_remote_code,
-        token,
-    )
+        processor_info = _save_ctc_processor_bundle(
+            repo_id,
+            output_dir,
+            trust_remote_code,
+            token,
+        )
 
-    exported_xml = output_dir / "openvino_model.xml"
-    if not exported_xml.exists():
-        raise RuntimeError("OVModelForCTC export did not produce openvino_model.xml.")
+        exported_xml = export_dir / "openvino_model.xml"
+        if not exported_xml.exists():
+            raise RuntimeError("OVModelForCTC export did not produce openvino_model.xml.")
+        for metadata_file in ("config.json", "openvino_config.json"):
+            source_metadata = export_dir / metadata_file
+            if source_metadata.exists():
+                _copy_file_with_retry(source_metadata, output_dir / metadata_file)
 
-    preserve_precision = _bool_env("OPENVINO_HF_CONVERTER_CTC_PRESERVE_PRECISION", False)
-    if not preserve_precision:
-        source_model = ov.Core().read_model(str(exported_xml))
-        compressed = _compress_to_int8(source_model)
-        _save_ov_model(compressed, exported_xml)
+        preserve_precision = _bool_env("OPENVINO_HF_CONVERTER_CTC_PRESERVE_PRECISION", False)
+        if preserve_precision:
+            _copy_file_with_retry(exported_xml, output_dir / "openvino_model.xml")
+            _copy_file_with_retry(exported_xml.with_suffix(".bin"), output_dir / "openvino_model.bin")
+        else:
+            source_model = ov.Core().read_model(str(exported_xml))
+            compressed = _compress_to_int8(source_model)
+            del source_model
+            gc.collect()
+            _save_ov_model(compressed, output_dir / "openvino_model.xml")
+            del compressed
+            gc.collect()
 
     return {
         "mode": "ovmodel-for-ctc-export",
@@ -652,7 +780,7 @@ def _export_whisper_asr_with_ovmodel(repo_id: str, output_dir: pathlib.Path, tru
 
     from optimum.intel import OVModelForSpeechSeq2Seq  # type: ignore
 
-    with tempfile.TemporaryDirectory(prefix="arcsub-ov-whisper-") as tmp_dir:
+    with _temporary_directory("arcsub-ov-whisper-") as tmp_dir:
         snapshot_dir = _download_snapshot(repo_id, pathlib.Path(tmp_dir))
         print(
             f"[arcsub-convert] Exporting Whisper ASR with OVModelForSpeechSeq2Seq from {snapshot_dir}",
@@ -686,6 +814,139 @@ def _export_whisper_asr_with_ovmodel(repo_id: str, output_dir: pathlib.Path, tru
             "generatedFiles": _iter_repo_files(output_dir),
             "compressedFiles": compressed,
             "tokenizerFiles": tokenizers,
+        }
+
+
+def _build_cohere_decoder_prompt_ids(tokenizer, language: str = "en"):
+    tokens = [
+        "▁",
+        "<|startofcontext|>",
+        "<|startoftranscript|>",
+        "<|emo:undefined|>",
+        f"<|{language}|>",
+        f"<|{language}|>",
+        "<|pnc|>",
+        "<|noitn|>",
+        "<|notimestamp|>",
+        "<|nodiarize|>",
+    ]
+    ids = tokenizer.convert_tokens_to_ids(tokens)
+    if not isinstance(ids, list) or any(item is None or int(item) < 0 for item in ids):
+        raise RuntimeError("Unable to build Cohere ASR decoder prompt ids from tokenizer special tokens.")
+    return [int(item) for item in ids]
+
+
+def _export_cohere_asr_with_traced_ov(repo_id: str, output_dir: pathlib.Path, trust_remote_code: bool) -> dict:
+    ensure_python_packages(
+        {
+            "numpy": "numpy",
+            "torch": "torch",
+        },
+        reason="Cohere ASR OpenVINO export helper",
+    )
+    import numpy as np  # type: ignore
+    import torch  # type: ignore
+    from transformers import AutoModelForSpeechSeq2Seq  # type: ignore
+
+    class _CohereForwardWrapper(torch.nn.Module):
+        def __init__(self, model):
+            super().__init__()
+            self.model = model
+
+        def forward(self, input_features, length, decoder_input_ids, decoder_attention_mask):
+            return self.model(
+                input_features=input_features,
+                length=length,
+                decoder_input_ids=decoder_input_ids,
+                decoder_attention_mask=decoder_attention_mask,
+                use_cache=False,
+            ).logits
+
+    with _temporary_directory("arcsub-ov-cohere-asr-") as tmp_dir:
+        snapshot_dir = _download_snapshot(repo_id, pathlib.Path(tmp_dir))
+        with open(snapshot_dir / "config.json", "r", encoding="utf-8") as file_obj:
+            config = json.load(file_obj)
+        model_type = str(config.get("model_type") or "").strip().lower()
+        if model_type != "cohere_asr":
+            raise RuntimeError(f"Cohere ASR exporter only supports model_type=cohere_asr, got {model_type or 'unknown'}.")
+
+        sample_rate = int(config.get("sample_rate") or config.get("preprocessor", {}).get("sample_rate") or 16000)
+        max_audio_clip_s = float(config.get("max_audio_clip_s") or 35.0)
+        example_seconds = float(os.environ.get("OPENVINO_COHERE_ASR_EXPORT_EXAMPLE_SECONDS", "8") or "8")
+        example_seconds = max(1.0, min(example_seconds, max_audio_clip_s))
+        dummy_audio = np.zeros((max(1, int(round(sample_rate * example_seconds))),), dtype=np.float32)
+
+        print(
+            f"[arcsub-convert] Exporting Cohere ASR traced OpenVINO INT8 from {snapshot_dir} "
+            f"(example_seconds={example_seconds:g})",
+            file=sys.stderr,
+            flush=True,
+        )
+        processor = AutoProcessor.from_pretrained(
+            str(snapshot_dir),
+            trust_remote_code=True,
+            local_files_only=True,
+        )
+        inputs = processor(dummy_audio, sampling_rate=sample_rate, return_tensors="pt")
+        prompt_ids = _build_cohere_decoder_prompt_ids(processor.tokenizer, "en")
+        example_inputs = (
+            inputs["input_features"].clone(),
+            inputs["length"].clone(),
+            torch.tensor([prompt_ids], dtype=torch.long),
+            torch.ones((1, len(prompt_ids)), dtype=torch.long),
+        )
+
+        model = AutoModelForSpeechSeq2Seq.from_pretrained(
+            str(snapshot_dir),
+            dtype=torch.float32,
+            local_files_only=True,
+            trust_remote_code=True,
+        )
+        model.eval()
+        wrapper = _CohereForwardWrapper(model).eval()
+        torch.set_grad_enabled(False)
+        traced = torch.jit.trace(wrapper, example_inputs, check_trace=False)
+        ov_model = ov.convert_model(traced, example_input=example_inputs)
+        del traced
+        del wrapper
+        del model
+        gc.collect()
+
+        compressed = _compress_to_int8(ov_model)
+        del ov_model
+        gc.collect()
+        _save_ov_model(compressed, output_dir / "openvino_model.xml")
+        del compressed
+        gc.collect()
+
+        copied = _copy_repo_metadata(snapshot_dir, output_dir)
+        marker = {
+            "runtimeKind": "cohere_openvino_asr",
+            "repoId": repo_id,
+            "modelType": model_type,
+            "exportMode": "torchscript-forward-int8",
+            "exampleSeconds": example_seconds,
+            "sampleRate": sample_rate,
+            "maxAudioClipSec": max_audio_clip_s,
+            "inputOrder": ["input_features", "length", "decoder_input_ids", "decoder_attention_mask"],
+            "promptLanguage": "en",
+            "decoderPromptIds": prompt_ids,
+            "notes": [
+                "This IR is a Cohere ASR forward model. ArcSub performs greedy autoregressive decoding in the ASR helper.",
+                "The model card requires an explicit source language; native timestamps and diarization are not emitted by this model.",
+            ],
+        }
+        (output_dir / COHERE_ASR_OV_MARKER_FILE).write_text(json.dumps(marker, ensure_ascii=True, indent=2), encoding="utf-8")
+
+        return {
+            "mode": "cohere-asr-traced-forward-int8",
+            "repoId": repo_id,
+            "snapshotFiles": _iter_repo_files(snapshot_dir),
+            "generatedFiles": _iter_repo_files(output_dir),
+            "copiedMetadataFiles": copied,
+            "compressedFiles": ["openvino_model.xml"],
+            "markerFile": COHERE_ASR_OV_MARKER_FILE,
+            "exampleSeconds": example_seconds,
         }
 
 
@@ -749,13 +1010,15 @@ def _maybe_bootstrap_optimum() -> None:
 def _run_optimum_export(repo_id: str, output_dir: pathlib.Path, hf_task: str | None, trust_remote_code: bool) -> dict:
     _maybe_bootstrap_optimum()
     snapshot_files: list[str] = []
-    with tempfile.TemporaryDirectory(prefix="arcsub-ov-export-") as tmp_dir:
+    with _temporary_directory("arcsub-ov-export-") as tmp_dir:
         snapshot_dir = _download_snapshot(repo_id, pathlib.Path(tmp_dir))
         snapshot_files = _iter_repo_files(snapshot_dir)
         command = [
             sys.executable,
             "-m",
-            "optimum.exporters.openvino",
+            "optimum.commands.optimum_cli",
+            "export",
+            "openvino",
             "--model",
             str(snapshot_dir),
             "--weight-format",
@@ -805,7 +1068,7 @@ def _convert_via_snapshot(
     runtime_layout: str,
     trust_remote_code: bool,
 ) -> dict:
-    with tempfile.TemporaryDirectory(prefix="arcsub-ov-convert-") as tmp_dir:
+    with _temporary_directory("arcsub-ov-convert-") as tmp_dir:
         work_dir = pathlib.Path(tmp_dir)
         snapshot_dir = _download_snapshot(repo_id, work_dir)
 
@@ -859,7 +1122,7 @@ def main() -> int:
     output_dir = pathlib.Path(args.output_dir).resolve()
     _assert_safe_output_dir(output_dir)
     if output_dir.exists():
-        shutil.rmtree(output_dir, ignore_errors=True)
+        _remove_tree_with_retry(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     trust_remote_code = _bool_env("OPENVINO_HF_EXPORT_TRUST_REMOTE_CODE", False)
@@ -878,6 +1141,8 @@ def main() -> int:
                     result = _run_optimum_export(args.repo_id, output_dir, task_name or None, trust_remote_code)
             elif args.conversion_method == "openvino-ctc-asr-export":
                 result = _export_ctc_asr_with_ovmodel(args.repo_id, output_dir, trust_remote_code)
+            elif args.conversion_method == "openvino-cohere-asr-export":
+                result = _export_cohere_asr_with_traced_ov(args.repo_id, output_dir, trust_remote_code=True)
             elif args.conversion_method == "openvino-convert-model":
                 result = _convert_via_snapshot(
                     args.repo_id,

--- a/tools_src/openvino_whisper_helper.py
+++ b/tools_src/openvino_whisper_helper.py
@@ -11,10 +11,14 @@ JSON IPC over stdin/stdout (one JSON object per line):
 from __future__ import annotations
 
 import gc
+import importlib
+import importlib.util
 import json
+import math
 import os
 import pathlib
 import re
+import subprocess
 import time
 import sys
 import traceback
@@ -39,6 +43,124 @@ from qwen3_asr_official_support import (
 )
 
 
+def _version_tuple(value: str) -> tuple[int, int, int]:
+    numbers = [int(part) for part in re.findall(r"\d+", str(value or ""))[:3]]
+    while len(numbers) < 3:
+        numbers.append(0)
+    return numbers[0], numbers[1], numbers[2]
+
+
+def _runtime_root() -> pathlib.Path:
+    configured = (
+        os.environ.get("ARCSUB_RUNTIME_DIR")
+        or os.environ.get("APP_RUNTIME_DIR")
+        or os.environ.get("APP_RUNTIME_PATH")
+    )
+    if configured:
+        return pathlib.Path(configured).expanduser().resolve()
+    return (SCRIPT_DIR.parent / "runtime").resolve()
+
+
+def _module_loaded_from(target_dir: pathlib.Path, module_name: str) -> bool:
+    module = sys.modules.get(module_name)
+    if module is None:
+        return False
+    locations = []
+    origin = getattr(module, "__file__", None)
+    if origin:
+        locations.append(origin)
+    spec = getattr(module, "__spec__", None)
+    if spec is not None:
+        spec_origin = getattr(spec, "origin", None)
+        if spec_origin:
+            locations.append(spec_origin)
+        search_locations = getattr(spec, "submodule_search_locations", None) or []
+        locations.extend([str(item) for item in search_locations])
+    if not locations:
+        return False
+    try:
+        target = target_dir.resolve()
+        return any(pathlib.Path(item).resolve().is_relative_to(target) for item in locations)
+    except Exception:
+        return False
+
+
+def _clear_loaded_module_tree(prefixes: tuple[str, ...]) -> None:
+    for name in list(sys.modules.keys()):
+        if name in prefixes or any(name.startswith(f"{prefix}.") for prefix in prefixes):
+            sys.modules.pop(name, None)
+
+
+def _cohere_transformers_site() -> pathlib.Path:
+    return _runtime_root() / "tools" / "python" / "cohere-transcribe-03-2026-site"
+
+
+def _cohere_transformers_ready(target_dir: pathlib.Path) -> bool:
+    target_text = str(target_dir)
+    if target_text not in sys.path:
+        sys.path.insert(0, target_text)
+        importlib.invalidate_caches()
+
+    if "transformers" in sys.modules and not _module_loaded_from(target_dir, "transformers"):
+        _clear_loaded_module_tree(("transformers", "huggingface_hub", "tokenizers", "safetensors"))
+
+    try:
+        import transformers  # pylint: disable=import-error,import-outside-toplevel
+    except Exception:
+        return False
+
+    return _module_loaded_from(target_dir, "transformers") and _version_tuple(
+        getattr(transformers, "__version__", "0.0.0")
+    ) >= (5, 4, 0)
+
+
+def _ensure_cohere_transformers_runtime() -> pathlib.Path:
+    target_dir = _cohere_transformers_site()
+    target_dir.mkdir(parents=True, exist_ok=True)
+    if _cohere_transformers_ready(target_dir):
+        return target_dir
+
+    if not str(os.environ.get("ARCSUB_AUTO_INSTALL_PYTHON_DEPS", "1")).strip().lower() in (
+        "",
+        "1",
+        "true",
+        "yes",
+        "on",
+    ):
+        raise ModuleNotFoundError(
+            "Cohere Transcribe requires isolated Python packages under runtime/tools/python: "
+            "transformers>=5.4.0, protobuf, sentencepiece."
+        )
+
+    sys.stderr.write(
+        "[arcsub-python-bootstrap] Installing isolated Python packages for Cohere Transcribe ASR: "
+        "transformers>=5.4.0, protobuf, sentencepiece\n"
+    )
+    sys.stderr.flush()
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "--target",
+            str(target_dir),
+            "transformers>=5.4.0",
+            "protobuf",
+            "sentencepiece",
+        ],
+        check=True,
+    )
+    _clear_loaded_module_tree(("transformers", "huggingface_hub", "tokenizers", "safetensors", "google.protobuf"))
+    importlib.invalidate_caches()
+    if not _cohere_transformers_ready(target_dir):
+        raise ModuleNotFoundError(
+            f"Cohere Transcribe isolated Transformers runtime is unavailable after installation: {target_dir}"
+        )
+    return target_dir
+
+
 def _normalize_whisper_language(raw: Optional[str]) -> Optional[str]:
     value = str(raw or "").strip()
     if not value:
@@ -61,6 +183,18 @@ def _normalize_whisper_language(raw: Optional[str]) -> Optional[str]:
 
 
 def _detect_runtime_kind(model_dir: pathlib.Path) -> str:
+    cohere_ov_required = [
+        "arcsub_cohere_asr_ov_config.json",
+        "config.json",
+        "preprocessor_config.json",
+        "processor_config.json",
+        "tokenizer_config.json",
+        "openvino_model.xml",
+        "openvino_model.bin",
+    ]
+    if all((model_dir / name).exists() for name in cohere_ov_required):
+        return "cohere_openvino_asr"
+
     ctc_required = [
         "config.json",
         "preprocessor_config.json",
@@ -85,6 +219,18 @@ def _detect_runtime_kind(model_dir: pathlib.Path) -> str:
     has_official_template = (model_dir / "chat_template.jinja").exists() or (model_dir / "chat_template.json").exists()
     if has_official_template and all((model_dir / name).exists() for name in official_qwen_base_required):
         return "qwen3_asr_official"
+    cohere_required = [
+        "config.json",
+        "preprocessor_config.json",
+        "tokenizer_config.json",
+        "model.safetensors",
+        "configuration_cohere_asr.py",
+        "modeling_cohere_asr.py",
+        "processing_cohere_asr.py",
+        "tokenization_cohere_asr.py",
+    ]
+    if all((model_dir / name).exists() for name in cohere_required):
+        return "cohere_transformers_asr"
     if (model_dir / "openvino_encoder_model.xml").exists():
         return "whisper"
     raise RuntimeError(f"Unsupported ASR model layout: {model_dir}")
@@ -141,6 +287,11 @@ class RuntimeState:
     pipeline: Any = None
     ctc_model: Any = None
     ctc_processor: Any = None
+    hf_asr_model: Any = None
+    hf_asr_processor: Any = None
+    cohere_ov_compiled_model: Any = None
+    cohere_ov_marker: Optional[Dict[str, Any]] = None
+    torch: Any = None
     qwen_official_model: Any = None
     qwen_official_forced_aligner: Any = None
     runtime_kind: Optional[str] = None
@@ -186,6 +337,10 @@ class RuntimeState:
         self.pipeline = None
         self.ctc_model = None
         self.ctc_processor = None
+        self.hf_asr_model = None
+        self.hf_asr_processor = None
+        self.cohere_ov_compiled_model = None
+        self.cohere_ov_marker = None
         self.qwen_official_model = None
         self.qwen_official_forced_aligner = None
         self.runtime_kind = None
@@ -230,6 +385,8 @@ class RuntimeState:
             self.ensure_common_modules()
             self.pipeline = None
             self.qwen_official_model = None
+            self.hf_asr_model = None
+            self.hf_asr_processor = None
             self.ctc_processor = AutoProcessor.from_pretrained(str(model_dir), local_files_only=True, trust_remote_code=False)
             self.ctc_model = OVModelForCTC.from_pretrained(
                 str(model_dir),
@@ -239,10 +396,80 @@ class RuntimeState:
                 trust_remote_code=False,
             )
             self.ctc_model.compile()
+        elif runtime_kind == "cohere_openvino_asr":
+            ensure_python_packages(
+                {
+                    "torch": "torch",
+                    "soundfile": "soundfile",
+                    "librosa": "librosa",
+                },
+                reason="OpenVINO Cohere ASR helper",
+            )
+            self.ensure_common_modules()
+            _ensure_cohere_transformers_runtime()
+            import torch  # pylint: disable=import-error
+            from transformers import AutoProcessor  # pylint: disable=import-error
+
+            marker_path = model_dir / "arcsub_cohere_asr_ov_config.json"
+            try:
+                self.cohere_ov_marker = json.loads(marker_path.read_text(encoding="utf-8"))
+            except Exception:
+                self.cohere_ov_marker = {}
+
+            self.pipeline = None
+            self.ctc_model = None
+            self.ctc_processor = None
+            self.hf_asr_model = None
+            self.qwen_official_model = None
+            self.hf_asr_processor = AutoProcessor.from_pretrained(
+                str(model_dir),
+                local_files_only=True,
+                trust_remote_code=False,
+            )
+            core = self.openvino.Core()
+            self.cohere_ov_compiled_model = core.compile_model(str(model_dir / "openvino_model.xml"), device)
+            self.torch = torch
+        elif runtime_kind == "cohere_transformers_asr":
+            ensure_python_packages(
+                {
+                    "torch": "torch",
+                    "soundfile": "soundfile",
+                    "librosa": "librosa",
+                },
+                reason="HF Transformers ASR helper",
+            )
+            self.ensure_common_modules()
+            _ensure_cohere_transformers_runtime()
+            import torch  # pylint: disable=import-error
+            from transformers import AutoProcessor, CohereAsrForConditionalGeneration  # pylint: disable=import-error
+
+            self.pipeline = None
+            self.ctc_model = None
+            self.ctc_processor = None
+            self.qwen_official_model = None
+            requested = str(device or "").strip().lower()
+            torch_device = "cuda" if requested not in ("cpu",) and torch.cuda.is_available() else "cpu"
+            torch_dtype = torch.float16 if torch_device == "cuda" else torch.float32
+            self.hf_asr_processor = AutoProcessor.from_pretrained(
+                str(model_dir),
+                local_files_only=True,
+                trust_remote_code=False,
+            )
+            self.hf_asr_model = CohereAsrForConditionalGeneration.from_pretrained(
+                str(model_dir),
+                local_files_only=True,
+                dtype=torch_dtype,
+            )
+            self.hf_asr_model.to(torch_device)
+            self.hf_asr_model.eval()
+            self.torch = torch
+            device = "CPU" if torch_device == "cpu" else "CUDA"
         else:
             self.pipeline = None
             self.ctc_model = None
             self.ctc_processor = None
+            self.hf_asr_model = None
+            self.hf_asr_processor = None
             self.qwen_official_model = create_official_qwen3_asr_model(str(model_dir), device=device)
 
         self.runtime_kind = runtime_kind
@@ -263,6 +490,376 @@ class RuntimeState:
             raise RuntimeError(f"Audio file not found: {file_path}")
         audio, _sr = self.librosa.load(str(file_path), sr=16000, mono=True)
         return audio
+
+    def _normalize_cohere_language(self, raw: Optional[str]) -> str:
+        value = str(raw or "").strip().lower().replace("_", "-")
+        aliases = {
+            "zh-cn": "zh",
+            "zh-tw": "zh",
+            "zh-hk": "zh",
+            "zh-hans": "zh",
+            "zh-hant": "zh",
+            "cmn": "zh",
+            "cmn-hans-cn": "zh",
+            "yue": "zh",
+            "yue-hant-hk": "zh",
+            "jp": "ja",
+            "ja-jp": "ja",
+            "kr": "ko",
+            "ko-kr": "ko",
+            "pt-br": "pt",
+            "pt-pt": "pt",
+            "es-419": "es",
+            "en-us": "en",
+            "en-gb": "en",
+            "ar-eg": "ar",
+            "de-de": "de",
+            "el-gr": "el",
+            "fr-fr": "fr",
+            "it-it": "it",
+            "nl-nl": "nl",
+            "pl-pl": "pl",
+            "vi-vn": "vi",
+        }
+        normalized = aliases.get(value, value)
+        if normalized in ("auto", "none", "null", ""):
+            raise RuntimeError(
+                "Cohere Transcribe requires an explicit source language. Supported languages: "
+                "ar, de, el, en, es, fr, it, ja, ko, nl, pl, pt, vi, zh."
+            )
+        supported = {"ar", "de", "el", "en", "es", "fr", "it", "ja", "ko", "nl", "pl", "pt", "vi", "zh"}
+        if normalized not in supported:
+            raise RuntimeError(
+                f'Cohere Transcribe does not support language "{raw}". Supported languages: '
+                "ar, de, el, en, es, fr, it, ja, ko, nl, pl, pt, vi, zh."
+            )
+        return normalized
+
+    def _move_batch_to_model_device(self, inputs: Any) -> Any:
+        if self.torch is None or self.hf_asr_model is None:
+            return inputs
+        device = next(self.hf_asr_model.parameters()).device
+        dtype = getattr(self.hf_asr_model, "dtype", self.torch.float32)
+        if hasattr(inputs, "to"):
+            try:
+                return inputs.to(device, dtype=dtype)
+            except TypeError:
+                return inputs.to(device)
+        for key, value in list(inputs.items()):
+            if not hasattr(value, "to"):
+                continue
+            if hasattr(value, "is_floating_point") and value.is_floating_point():
+                inputs[key] = value.to(device=device, dtype=dtype)
+            else:
+                inputs[key] = value.to(device=device)
+        return inputs
+
+    def _decode_cohere_output(self, outputs: Any, audio_chunk_index: Any, language: str) -> str:
+        if self.hf_asr_processor is None:
+            return ""
+        try:
+            decoded = self.hf_asr_processor.decode(
+                outputs,
+                skip_special_tokens=True,
+                audio_chunk_index=audio_chunk_index,
+                language=language,
+            )
+        except TypeError:
+            decoded = self.hf_asr_processor.decode(outputs, skip_special_tokens=True)
+        if isinstance(decoded, (list, tuple)):
+            return " ".join(str(item).strip() for item in decoded if str(item).strip()).strip()
+        return str(decoded or "").strip()
+
+    def _as_numpy(self, value: Any, dtype: Any = None):
+        if hasattr(value, "detach"):
+            value = value.detach().cpu().numpy()
+        elif hasattr(value, "cpu") and hasattr(value, "numpy"):
+            value = value.cpu().numpy()
+        else:
+            value = self.numpy.asarray(value)
+        return value.astype(dtype) if dtype is not None else value
+
+    def _cohere_join_texts(self, texts: list[str], language: str) -> str:
+        parts = [str(item or "").strip() for item in texts if str(item or "").strip()]
+        if not parts:
+            return ""
+        separator = "" if language in {"ja", "zh"} else " "
+        return separator.join(parts).replace("  ", " ").strip()
+
+    def _cohere_split_audio(self, audio: Any) -> list[tuple[float, Any]]:
+        total_samples = int(len(audio)) if hasattr(audio, "__len__") else 0
+        if total_samples <= 0:
+            return []
+        marker = self.cohere_ov_marker or {}
+        try:
+            max_clip_sec = float(marker.get("maxAudioClipSec") or 35.0)
+        except Exception:
+            max_clip_sec = 35.0
+        raw_chunk_sec = str(os.environ.get("OPENVINO_COHERE_ASR_CHUNK_SEC", "")).strip()
+        try:
+            chunk_sec = float(raw_chunk_sec) if raw_chunk_sec else min(30.0, max_clip_sec)
+        except Exception:
+            chunk_sec = min(30.0, max_clip_sec)
+        chunk_sec = max(1.0, min(chunk_sec, max_clip_sec))
+        chunk_samples = max(1, int(round(chunk_sec * 16000)))
+        chunks: list[tuple[float, Any]] = []
+        for start in range(0, total_samples, chunk_samples):
+            end = min(total_samples, start + chunk_samples)
+            if end <= start:
+                continue
+            chunks.append((start / 16000.0, audio[start:end]))
+        return chunks
+
+    def _cohere_split_text_for_display(self, text: str, language: str) -> list[str]:
+        normalized = re.sub(r"\s+", " ", str(text or "")).strip()
+        if not normalized:
+            return []
+        no_space = language in {"ja", "zh"}
+        max_chars = 42 if no_space else 118
+        hard_max_chars = 58 if no_space else 160
+        primary_pattern = r"(?<=[。！？!?])" if no_space else r"(?<=[.!?])\s+"
+        raw_parts = [part.strip() for part in re.split(primary_pattern, normalized) if part.strip()]
+        if not raw_parts:
+            raw_parts = [normalized]
+
+        parts: list[str] = []
+        for raw in raw_parts:
+            pending = raw
+            while len(pending) > hard_max_chars:
+                window = pending[:hard_max_chars]
+                break_at = -1
+                for pattern in (r"[、，,;；:：]\s*", r"\s+"):
+                    matches = list(re.finditer(pattern, window))
+                    matches = [match for match in matches if match.end() >= max_chars]
+                    if matches:
+                        break_at = matches[-1].end()
+                        break
+                if break_at <= 0:
+                    break_at = hard_max_chars
+                head = pending[:break_at].strip()
+                if head:
+                    parts.append(head)
+                pending = pending[break_at:].strip()
+            if pending:
+                parts.append(pending)
+        return parts or [normalized]
+
+    def _cohere_make_display_chunks(self, text: str, start_sec: float, end_sec: float, language: str) -> list[Dict[str, Any]]:
+        parts = self._cohere_split_text_for_display(text, language)
+        if not parts:
+            return []
+        start = float(start_sec)
+        end = float(end_sec)
+        if not math.isfinite(end) or end <= start:
+            end = start + max(0.4, len(parts) * 0.8)
+        duration = max(0.4, end - start)
+        weights = [max(1, len(re.sub(r"\s+", "", part))) for part in parts]
+        total_weight = max(1, sum(weights))
+        cursor = start
+        chunks: list[Dict[str, Any]] = []
+        for index, part in enumerate(parts):
+            if index + 1 == len(parts):
+                part_end = end
+            else:
+                part_end = start + duration * (sum(weights[: index + 1]) / total_weight)
+            if part_end <= cursor:
+                part_end = cursor + 0.4
+            chunks.append(
+                {
+                    "start_ts": round(cursor, 3),
+                    "end_ts": round(part_end, 3),
+                    "text": part,
+                    "source": "cohere_display_sentence",
+                }
+            )
+            cursor = part_end
+        return chunks
+
+    def _cohere_decode_ids(self, token_ids: Any, audio_chunk_index: Any, language: str) -> str:
+        if self.hf_asr_processor is None:
+            return ""
+        decoded = self.hf_asr_processor.decode(
+            token_ids,
+            skip_special_tokens=True,
+            audio_chunk_index=audio_chunk_index,
+            language=language,
+        )
+        return _coerce_text_payload(decoded[0] if isinstance(decoded, list) and decoded else decoded)
+
+    def _transcribe_cohere_openvino(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if self.cohere_ov_compiled_model is None or self.hf_asr_processor is None or self.numpy is None:
+            raise RuntimeError("OpenVINO Cohere ASR model is not loaded.")
+
+        audio_path = str(params.get("audioPath") or "").strip()
+        if not audio_path:
+            raise RuntimeError("audioPath is required.")
+
+        language = self._normalize_cohere_language(params.get("language"))
+        audio = self._read_audio(audio_path)
+        started_at = time.time()
+        duration_sec = float(len(audio) / 16000.0) if hasattr(audio, "__len__") else 0.0
+
+        raw_max_new_tokens = str(
+            os.environ.get("OPENVINO_COHERE_ASR_MAX_NEW_TOKENS")
+            or os.environ.get("HF_TRANSFORMERS_ASR_MAX_NEW_TOKENS")
+            or ""
+        ).strip()
+        try:
+            base_max_new_tokens = int(raw_max_new_tokens) if raw_max_new_tokens else int(math.ceil(duration_sec * 8.0) + 24)
+        except ValueError:
+            base_max_new_tokens = int(math.ceil(duration_sec * 8.0) + 24)
+        base_max_new_tokens = max(32, min(base_max_new_tokens, 256))
+
+        eos_token_id = int(getattr(self.hf_asr_processor.tokenizer, "eos_token_id", 3) or 3)
+        chunks = self._cohere_split_audio(audio)
+        transcript_chunks: list[Dict[str, Any]] = []
+        generated_texts: list[str] = []
+        inference_ms = 0
+        token_count = 0
+        return_timestamps = bool(params.get("returnTimestamps", True))
+
+        for chunk_index, (offset_sec, chunk_audio) in enumerate(chunks):
+            chunk_duration_sec = float(len(chunk_audio) / 16000.0) if hasattr(chunk_audio, "__len__") else 0.0
+            chunk_max_new_tokens = max(16, min(base_max_new_tokens, int(math.ceil(chunk_duration_sec * 8.0) + 24)))
+            inputs = self.hf_asr_processor(
+                chunk_audio,
+                sampling_rate=16000,
+                return_tensors="pt",
+                language=language,
+                punctuation=True,
+            )
+            audio_chunk_index = inputs.get("audio_chunk_index") if hasattr(inputs, "get") else None
+            input_features = self._as_numpy(inputs["input_features"], self.numpy.float32)
+            if input_features.ndim == 3 and input_features.shape[-1] == 128:
+                input_features = self.numpy.transpose(input_features, (0, 2, 1)).astype(self.numpy.float32)
+            attention_mask = self._as_numpy(inputs.get("attention_mask"), self.numpy.int64)
+            length = attention_mask.sum(axis=1).astype(self.numpy.int64)
+            decoder_input_ids = self._as_numpy(inputs["decoder_input_ids"], self.numpy.int64)
+
+            for _step in range(chunk_max_new_tokens):
+                decoder_attention_mask = self.numpy.ones_like(decoder_input_ids, dtype=self.numpy.int64)
+                feed = {
+                    self.cohere_ov_compiled_model.inputs[0]: input_features,
+                    self.cohere_ov_compiled_model.inputs[1]: length,
+                    self.cohere_ov_compiled_model.inputs[2]: decoder_input_ids,
+                    self.cohere_ov_compiled_model.inputs[3]: decoder_attention_mask,
+                }
+                infer_started = time.time()
+                result = self.cohere_ov_compiled_model(feed)
+                inference_ms += int(max(0, time.time() - infer_started) * 1000)
+                logits = list(result.values())[0]
+                next_token_id = int(self.numpy.argmax(logits[0, -1, :]))
+                decoder_input_ids = self.numpy.concatenate(
+                    [decoder_input_ids, self.numpy.array([[next_token_id]], dtype=self.numpy.int64)],
+                    axis=1,
+                )
+                token_count += 1
+                if next_token_id == eos_token_id:
+                    break
+
+            text = self._cohere_decode_ids(decoder_input_ids, audio_chunk_index, language)
+            if text:
+                generated_texts.append(text)
+                if return_timestamps:
+                    transcript_chunks.extend(
+                        self._cohere_make_display_chunks(text, offset_sec, offset_sec + chunk_duration_sec, language)
+                    )
+                else:
+                    transcript_chunks.append(
+                        {
+                            "start_ts": offset_sec,
+                            "end_ts": offset_sec + chunk_duration_sec,
+                            "text": text,
+                            "source": "cohere_model_window",
+                        }
+                    )
+
+        text = self._cohere_join_texts(generated_texts, language)
+        return {
+            "text": text,
+            "chunks": transcript_chunks,
+            "words": [],
+            "runtimeKind": self.runtime_kind,
+            "modelPath": self.model_path,
+            "device": self.device,
+            "language": language,
+            "chunking": {
+                "strategy": "cohere_openvino_greedy",
+                "chunkCount": len(chunks),
+                "maxNewTokens": base_max_new_tokens,
+                "generatedTokens": token_count,
+            },
+            "timing": {
+                "generateMs": int(max(0, time.time() - started_at) * 1000),
+                "inferenceMs": inference_ms,
+                "audioDurationSec": duration_sec,
+            },
+        }
+
+    def _transcribe_cohere_transformers(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if self.hf_asr_model is None or self.hf_asr_processor is None or self.torch is None:
+            raise RuntimeError("HF Transformers ASR model is not loaded.")
+
+        audio_path = str(params.get("audioPath") or "").strip()
+        if not audio_path:
+            raise RuntimeError("audioPath is required.")
+
+        language = self._normalize_cohere_language(params.get("language"))
+        audio = self._read_audio(audio_path)
+        started_at = time.time()
+
+        duration_sec = float(len(audio) / 16000.0) if hasattr(audio, "__len__") else 0.0
+        raw_max_new_tokens = str(os.environ.get("HF_TRANSFORMERS_ASR_MAX_NEW_TOKENS", "")).strip()
+        try:
+            max_new_tokens = int(raw_max_new_tokens) if raw_max_new_tokens else int(math.ceil(duration_sec * 8.0) + 24)
+        except ValueError:
+            max_new_tokens = int(math.ceil(duration_sec * 8.0) + 24)
+        max_new_tokens = max(32, min(max_new_tokens, 256))
+
+        inputs = self.hf_asr_processor(
+            audio,
+            sampling_rate=16000,
+            return_tensors="pt",
+            language=language,
+            punctuation=True,
+        )
+        audio_chunk_index = inputs.get("audio_chunk_index") if hasattr(inputs, "get") else None
+        inputs = self._move_batch_to_model_device(inputs)
+
+        with self.torch.inference_mode():
+            outputs = self.hf_asr_model.generate(**inputs, max_new_tokens=max_new_tokens)
+        decoded = self.hf_asr_processor.decode(
+            outputs,
+            skip_special_tokens=True,
+            audio_chunk_index=audio_chunk_index,
+            language=language,
+        )
+        text = _coerce_text_payload(decoded[0] if isinstance(decoded, list) and decoded else decoded)
+        if bool(params.get("returnTimestamps", True)):
+            chunks = self._cohere_make_display_chunks(text, 0.0, duration_sec, language)
+        else:
+            chunk = {"start_ts": 0.0, "text": text, "source": "cohere_model_window"}
+            if duration_sec > 0:
+                chunk["end_ts"] = duration_sec
+            chunks = [chunk] if text else []
+        return {
+            "text": text,
+            "chunks": chunks,
+            "words": [],
+            "runtimeKind": self.runtime_kind,
+            "modelPath": self.model_path,
+            "device": self.device,
+            "language": language,
+            "chunking": {
+                "strategy": "cohere_builtin_generate",
+                "maxNewTokens": max_new_tokens,
+                "audioChunkIndex": bool(audio_chunk_index is not None),
+            },
+            "timing": {
+                "generateMs": int(max(0, time.time() - started_at) * 1000),
+                "audioDurationSec": duration_sec,
+            },
+        }
 
     def _transcribe_whisper(self, params: Dict[str, Any]) -> Dict[str, Any]:
         if self.pipeline is None:
@@ -666,12 +1263,22 @@ class RuntimeState:
             return self._transcribe_ctc(params)
         if self.runtime_kind == "qwen3_asr_official":
             return self._transcribe_qwen_official(params)
+        if self.runtime_kind == "cohere_openvino_asr":
+            return self._transcribe_cohere_openvino(params)
+        if self.runtime_kind == "cohere_transformers_asr":
+            return self._transcribe_cohere_transformers(params)
         raise RuntimeError("ASR model is not loaded.")
 
     def health(self) -> Dict[str, Any]:
         return {
             "ready": True,
-            "modelLoaded": self.pipeline is not None or self.ctc_model is not None or self.qwen_official_model is not None,
+            "modelLoaded": (
+                self.pipeline is not None
+                or self.ctc_model is not None
+                or self.qwen_official_model is not None
+                or self.cohere_ov_compiled_model is not None
+                or self.hf_asr_model is not None
+            ),
             "modelPath": self.model_path,
             "device": self.device,
             "runtimeKind": self.runtime_kind,

--- a/tools_src/openvino_whisper_helper.py
+++ b/tools_src/openvino_whisper_helper.py
@@ -463,7 +463,7 @@ class RuntimeState:
             self.hf_asr_model.to(torch_device)
             self.hf_asr_model.eval()
             self.torch = torch
-            device = "CPU" if torch_device == "cpu" else "CUDA"
+            device = "CPU" if torch_device == "cpu" else "GPU"
         else:
             self.pipeline = None
             self.ctc_model = None

--- a/tools_src/qwen3_asr_official_support.py
+++ b/tools_src/qwen3_asr_official_support.py
@@ -31,7 +31,61 @@ THINKER_AUDIO_ENCODER_NAME = "openvino_thinker_audio_encoder_model.xml"
 THINKER_EMBEDDING_NAME = "openvino_thinker_embedding_model.xml"
 
 _WORKSPACE_ROOT = Path(__file__).resolve().parents[1]
-_CACHE_ROOT = _WORKSPACE_ROOT / "runtime" / "local" / "qwen3_asr_support"
+
+
+def _resolve_workspace_path(raw_path: str | None, fallback: Path) -> Path:
+    value = str(raw_path or "").strip()
+    if not value:
+        return fallback.resolve()
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        candidate = _WORKSPACE_ROOT / candidate
+    return candidate.resolve()
+
+
+def _resolve_runtime_root() -> Path:
+    return _resolve_workspace_path(
+        os.environ.get("ARCSUB_RUNTIME_DIR") or os.environ.get("APP_RUNTIME_DIR"),
+        _WORKSPACE_ROOT / "runtime",
+    )
+
+
+def _resolve_runtime_tmp_root() -> Path:
+    root = _resolve_workspace_path(
+        os.environ.get("ARCSUB_RUNTIME_TMP_DIR") or os.environ.get("APP_TMP_DIR"),
+        _resolve_runtime_root() / "tmp",
+    )
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _resolve_runtime_local_root() -> Path:
+    root = _resolve_workspace_path(os.environ.get("APP_LOCAL_DIR"), _resolve_runtime_root() / "local")
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+_RUNTIME_TMP_ROOT = _resolve_runtime_tmp_root()
+_CACHE_ROOT = _resolve_runtime_local_root() / "qwen3_asr_support"
+_TMP_ROOT = _RUNTIME_TMP_ROOT / "qwen3_asr_support"
+_HF_CACHE_ROOT = _RUNTIME_TMP_ROOT / "huggingface"
+_PIP_CACHE_ROOT = _RUNTIME_TMP_ROOT / "pip-cache"
+_TORCH_CACHE_ROOT = _RUNTIME_TMP_ROOT / "torch-cache"
+_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+_HF_CACHE_ROOT.mkdir(parents=True, exist_ok=True)
+_PIP_CACHE_ROOT.mkdir(parents=True, exist_ok=True)
+_TORCH_CACHE_ROOT.mkdir(parents=True, exist_ok=True)
+for _env_key in ("TMPDIR", "TEMP", "TMP"):
+    os.environ[_env_key] = str(_RUNTIME_TMP_ROOT)
+os.environ["ARCSUB_RUNTIME_TMP_DIR"] = str(_RUNTIME_TMP_ROOT)
+os.environ["APP_TMP_DIR"] = str(_RUNTIME_TMP_ROOT)
+os.environ["HF_HOME"] = str(_HF_CACHE_ROOT)
+os.environ["HF_HUB_CACHE"] = str(_HF_CACHE_ROOT / "hub")
+os.environ["HF_XET_CACHE"] = str(_HF_CACHE_ROOT / "xet")
+os.environ["HF_DATASETS_CACHE"] = str(_HF_CACHE_ROOT / "datasets")
+os.environ["PIP_CACHE_DIR"] = str(_PIP_CACHE_ROOT)
+os.environ["TORCH_HOME"] = str(_TORCH_CACHE_ROOT)
+tempfile.tempdir = str(_RUNTIME_TMP_ROOT)
 _LEGACY_LOCAL_CACHE_ROOT = _WORKSPACE_ROOT / "local" / "qwen3_asr_support"
 _LEGACY_TMP_CACHE_ROOT = _WORKSPACE_ROOT / "tmp" / "qwen3_asr_support"
 _HELPER_MODULE: Any = None
@@ -72,7 +126,8 @@ def _normalize_torch_dtype_name(raw: str | None) -> str:
 
 def _download_to_file(url: str, destination: Path) -> Path:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = destination.with_suffix(destination.suffix + ".part")
+    _TMP_ROOT.mkdir(parents=True, exist_ok=True)
+    temp_path = _TMP_ROOT / f"{destination.name}.{os.getpid()}.part"
     with urllib.request.urlopen(url) as response, temp_path.open("wb") as handle:
         shutil.copyfileobj(response, handle)
     temp_path.replace(destination)
@@ -86,7 +141,8 @@ def _download_and_extract_github_archive(repo: str, commit: str, destination: Pa
 
     archive_url = f"https://github.com/{repo}/archive/{commit}.zip"
     destination.parent.mkdir(parents=True, exist_ok=True)
-    temp_root = Path(tempfile.mkdtemp(prefix="arcsub_qwen3asr_", dir=str(destination.parent)))
+    _TMP_ROOT.mkdir(parents=True, exist_ok=True)
+    temp_root = Path(tempfile.mkdtemp(prefix="arcsub_qwen3asr_", dir=str(_TMP_ROOT)))
     archive_path = temp_root / "repo.zip"
     extracted_root = temp_root / "extract"
     try:


### PR DESCRIPTION
## Summary
- Add a Cohere Transcribe OpenVINO INT8 ASR runtime path while keeping the existing HF Transformers ASR fallback path.
- Extend local model catalog/runtime metadata, Settings labels, and ASR helper dispatch for Cohere, Qwen3, CTC, VAD, diarization, and runtime temp handling.
- Improve dev startup behavior: wait for runtime readiness before opening the browser, prevent Enter from restarting `tsx watch`, and set VS Code terminal UTF-8 defaults.

## Validation
- `python -m py_compile tools_src\convert_hf_model_to_openvino.py tools_src\openvino_whisper_helper.py tools_src\qwen3_asr_official_support.py`
- `powershell -NoProfile -ExecutionPolicy Bypass -Command '$null = [scriptblock]::Create((Get-Content -Raw .\start.ps1)); Write-Output "start.ps1 parse ok"'`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\start.ps1 -DryRun -NoBrowser`
- `npx tsc -p tsconfig.server.json --noEmit`
- `npx tsc --noEmit`
- `npm run -s build`

## Notes
- Local-only ignored folders such as `.agents/`, `.env`, `runtime/`, and `dist/` were not included in this PR.
- Cohere validation artifacts and converted runtime models remain local under `runtime/`.