### PR TITLE
[codex] Fix release runtime packaging and setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,10 @@ VAD_LOG_STATS=0
 
 # Silero backend override. If unset, ArcSub uses the bundled ONNX/OpenVINO path.
 # VAD_OPENVINO_MODEL_PATH=./runtime/models/silero_vad.xml
+# Silero ONNX Runtime providers used only when OpenVINO VAD is unavailable.
+# Default is CPU because DirectML/WebGPU can crash or fail on Windows VMs without GPU.
+# Valid values: cpu, directml, webgpu. To opt into GPU fallback, set directml,cpu or webgpu,cpu.
+VAD_ONNXRUNTIME_PROVIDERS=cpu
 
 # Ten VAD backend settings.
 # If TEN_VAD_MODEL_PATH is unset or missing, ArcSub downloads runtime/models/ten-vad.onnx.

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -780,7 +780,16 @@ $pythonExe = Ensure-PortablePython -RootDir $scriptPath -Manifest $manifest
 Ensure-PipAvailable -PythonExe $pythonExe -RootDir $scriptPath -Manifest $manifest
 Ensure-PythonPackagingTools -PythonExe $pythonExe -RootDir $scriptPath
 if (-not $SkipLocalModelPython) {
-  Ensure-WhisperAsrHelperPythonDependencies -PythonExe $pythonExe -RootDir $scriptPath
+  if ($PreinstallLocalModelPython) {
+    Ensure-WhisperAsrHelperPythonDependencies -PythonExe $pythonExe -RootDir $scriptPath
+  } else {
+    try {
+      Ensure-WhisperAsrHelperPythonDependencies -PythonExe $pythonExe -RootDir $scriptPath
+    } catch {
+      Write-Info "Whisper ASR helper Python dependency preinstall failed; continuing because local ASR helper setup is optional. Run deploy.ps1 -PreinstallLocalModelPython to require it."
+      Write-Info ([string]$_.Exception.Message)
+    }
+  }
 } else {
   Write-Info "Skipping local ASR helper Python dependency preinstall."
 }

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,7 +1,8 @@
 param(
   [switch]$SkipBuild,
   [switch]$SkipPyannote,
-  [switch]$PreinstallLocalModelPython
+  [switch]$PreinstallLocalModelPython,
+  [switch]$SkipLocalModelPython
 )
 
 $ErrorActionPreference = "Stop"
@@ -315,6 +316,101 @@ function Ensure-PipAvailable([string]$PythonExe, [string]$RootDir, $Manifest) {
   $null = Invoke-Process -FilePath $PythonExe -ArgumentList @($getPipPath, "--no-warn-script-location") -WorkingDirectory $RootDir -ExtraEnv $envPatch
 }
 
+function Ensure-PythonPackagingTools([string]$PythonExe, [string]$RootDir) {
+  $probeScript = @'
+import importlib.util
+
+missing = [
+    name
+    for name in ("setuptools", "wheel")
+    if importlib.util.find_spec(name) is None
+]
+print("\n".join(missing))
+'@
+
+  $probeScriptPath = Join-Path $RootDir ".arcsub-bootstrap\downloads\probe_python_packaging_tools.py"
+  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $probeScriptPath) | Out-Null
+  [System.IO.File]::WriteAllText($probeScriptPath, $probeScript, [System.Text.UTF8Encoding]::new($false))
+
+  $missingOutput = & $PythonExe $probeScriptPath 2>$null
+  $missing = @(
+    ($missingOutput -split "`r?`n" | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+  )
+  if ($missing.Count -eq 0) {
+    Write-Info "Python packaging tools already available."
+    return
+  }
+
+  Write-Step "Installing Python packaging tools..."
+  $pythonDir = Split-Path -Parent $PythonExe
+  $envPatch = @{
+    PATH = "$pythonDir;$env:PATH"
+  }
+  $null = Invoke-Process -FilePath $PythonExe -ArgumentList @("-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel") -WorkingDirectory $RootDir -ExtraEnv $envPatch
+}
+
+function Ensure-WhisperAsrHelperPythonDependencies([string]$PythonExe, [string]$RootDir) {
+  Write-Step "Ensuring Whisper ASR helper Python dependencies..."
+  $probeScript = @'
+import importlib.util
+
+def missing(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is None
+    except ModuleNotFoundError:
+        return True
+
+modules = [
+    "openvino",
+    "openvino_genai",
+    "transformers",
+    "librosa",
+    "numpy",
+]
+missing_names = [name for name in modules if missing(name)]
+print("\n".join(missing_names))
+'@
+
+  $probeScriptPath = Join-Path $RootDir ".arcsub-bootstrap\downloads\probe_whisper_asr_helper_deps.py"
+  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $probeScriptPath) | Out-Null
+  [System.IO.File]::WriteAllText($probeScriptPath, $probeScript, [System.Text.UTF8Encoding]::new($false))
+
+  $missingOutput = & $PythonExe $probeScriptPath 2>$null
+  $missing = @(
+    ($missingOutput -split "`r?`n" | ForEach-Object { [string]$_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+  )
+  if ($missing.Count -eq 0) {
+    Write-Info "Whisper ASR helper Python dependencies already available."
+    return
+  }
+
+  $packageMap = @{
+    "openvino" = @("openvino")
+    "openvino_genai" = @("openvino-genai")
+    "transformers" = @("transformers")
+    "librosa" = @("librosa")
+    "numpy" = @("numpy")
+  }
+
+  $packages = New-Object System.Collections.Generic.List[string]
+  foreach ($name in $missing) {
+    foreach ($package in ($packageMap[$name] | Where-Object { $_ })) {
+      if (-not $packages.Contains($package)) {
+        $packages.Add($package)
+      }
+    }
+  }
+  if ($packages.Count -eq 0) {
+    return
+  }
+
+  $envPatch = @{
+    PATH = "$(Split-Path -Parent $PythonExe);$env:PATH"
+  }
+  $args = @("-m", "pip", "install", "--upgrade") + @($packages.ToArray())
+  $null = Invoke-Process -FilePath $PythonExe -ArgumentList $args -WorkingDirectory $RootDir -ExtraEnv $envPatch
+}
+
 function Ensure-AsrHelperPythonDependencies([string]$PythonExe, [string]$RootDir) {
   Write-Step "Ensuring ASR helper Python dependencies..."
   $probeScript = @'
@@ -626,6 +722,51 @@ function Invoke-Npm([string]$NodeExe, [string]$NpmCmd, [string]$WorkingDirectory
   $null = Invoke-Process -FilePath $NpmCmd -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -ExtraEnv $envPatch
 }
 
+function Test-NodeNativeRuntimes([string]$RootDir, [string]$NodeExe) {
+  if (-not (Test-Path (Join-Path $RootDir "node_modules"))) {
+    return $false
+  }
+
+  $probeScript = @'
+await import("onnxruntime-node");
+await import("@huggingface/transformers");
+'@
+  $scriptPath = Join-Path ([System.IO.Path]::GetTempPath()) ("arcsub-native-runtime-probe-" + [Guid]::NewGuid().ToString("N") + ".mjs")
+  $stdoutPath = [System.IO.Path]::GetTempFileName()
+  $stderrPath = [System.IO.Path]::GetTempFileName()
+  try {
+    [System.IO.File]::WriteAllText($scriptPath, $probeScript, [System.Text.UTF8Encoding]::new($false))
+    $nodeDir = Split-Path -Parent $NodeExe
+    $originalPath = [Environment]::GetEnvironmentVariable("PATH", "Process")
+    [Environment]::SetEnvironmentVariable("PATH", "$nodeDir;$originalPath", "Process")
+    try {
+      $process = Start-Process `
+        -FilePath $NodeExe `
+        -ArgumentList @($scriptPath) `
+        -WorkingDirectory $RootDir `
+        -RedirectStandardOutput $stdoutPath `
+        -RedirectStandardError $stderrPath `
+        -NoNewWindow `
+        -Wait `
+        -PassThru
+      return $process.ExitCode -eq 0
+    } finally {
+      [Environment]::SetEnvironmentVariable("PATH", $originalPath, "Process")
+    }
+  } finally {
+    Remove-Item $scriptPath, $stdoutPath, $stderrPath -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Install-ReleaseRuntimeDependencies([string]$RootDir, [string]$NodeExe, [string]$NpmCmd) {
+  Write-Step "Installing release runtime dependencies..."
+  Invoke-Npm -NodeExe $NodeExe -NpmCmd $NpmCmd -WorkingDirectory $RootDir -Arguments @("install", "--omit=dev", "--no-fund", "--no-audit")
+  $finalizer = Join-Path $RootDir "scripts\finalize-runtime-install.mjs"
+  if (Test-Path $finalizer) {
+    $null = Invoke-Process -FilePath $NodeExe -ArgumentList @($finalizer) -WorkingDirectory $RootDir
+  }
+}
+
 $scriptPath = Split-Path -Parent $MyInvocation.MyCommand.Path
 $manifest = Get-DeployManifest -RootDir $scriptPath
 Set-ConsoleUtf8
@@ -635,11 +776,15 @@ Write-Info "Workspace: $scriptPath"
 $nodeExe = Ensure-PortableNode -RootDir $scriptPath
 $pythonExe = Ensure-PortablePython -RootDir $scriptPath -Manifest $manifest
 Ensure-PipAvailable -PythonExe $pythonExe -RootDir $scriptPath -Manifest $manifest
-if ($PreinstallLocalModelPython) {
+Ensure-PythonPackagingTools -PythonExe $pythonExe -RootDir $scriptPath
+if (-not $SkipLocalModelPython) {
+  Ensure-WhisperAsrHelperPythonDependencies -PythonExe $pythonExe -RootDir $scriptPath
+} else {
+  Write-Info "Skipping local ASR helper Python dependency preinstall."
+}
+if ($PreinstallLocalModelPython -and -not $SkipLocalModelPython) {
   Ensure-AsrHelperPythonDependencies -PythonExe $pythonExe -RootDir $scriptPath
   Ensure-AlignmentPythonDependencies -PythonExe $pythonExe -RootDir $scriptPath
-} else {
-  Write-Info "Deferring local-model Python dependency install until helper/conversion use."
 }
 $npmCmd = Get-NpmCmd -NodeExe $nodeExe
 $isSourceWorkspace = (Test-Path (Join-Path $scriptPath "src")) -and (Test-Path (Join-Path $scriptPath "server\index.ts"))
@@ -669,8 +814,12 @@ if ($isSourceWorkspace) {
   }
 } else {
   if (-not (Test-Path (Join-Path $scriptPath "node_modules"))) {
-    Write-Step "Installing release runtime dependencies..."
-    Invoke-Npm -NodeExe $nodeExe -NpmCmd $npmCmd -WorkingDirectory $scriptPath -Arguments @("install", "--omit=dev", "--no-fund", "--no-audit")
+    Install-ReleaseRuntimeDependencies -RootDir $scriptPath -NodeExe $nodeExe -NpmCmd $npmCmd
+  } elseif (-not (Test-NodeNativeRuntimes -RootDir $scriptPath -NodeExe $nodeExe)) {
+    Write-Step "Runtime dependencies failed native preload; reinstalling release runtime dependencies..."
+    Remove-Item -LiteralPath (Join-Path $scriptPath "node_modules") -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Join-Path $scriptPath "package-lock.json") -Force -ErrorAction SilentlyContinue
+    Install-ReleaseRuntimeDependencies -RootDir $scriptPath -NodeExe $nodeExe -NpmCmd $npmCmd
   }
 }
 

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -731,7 +731,9 @@ function Test-NodeNativeRuntimes([string]$RootDir, [string]$NodeExe) {
 await import("onnxruntime-node");
 await import("@huggingface/transformers");
 '@
-  $scriptPath = Join-Path ([System.IO.Path]::GetTempPath()) ("arcsub-native-runtime-probe-" + [Guid]::NewGuid().ToString("N") + ".mjs")
+  $probeDir = Join-Path $RootDir ".arcsub-bootstrap\downloads"
+  New-Item -ItemType Directory -Force -Path $probeDir | Out-Null
+  $scriptPath = Join-Path $probeDir ("arcsub-native-runtime-probe-" + [Guid]::NewGuid().ToString("N") + ".mjs")
   $stdoutPath = [System.IO.Path]::GetTempFileName()
   $stderrPath = [System.IO.Path]::GetTempFileName()
   try {

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,7 @@ required_python_minor=12
 skip_build=0
 skip_pyannote=0
 preinstall_local_model_python=0
+skip_local_model_python=0
 
 log() {
   printf '[ArcSub] %s\n' "$1"
@@ -117,6 +118,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     --preinstall-local-model-python)
       preinstall_local_model_python=1
+      ;;
+    --skip-local-model-python)
+      skip_local_model_python=1
       ;;
     *)
       fail "Unknown argument: $1"
@@ -283,6 +287,61 @@ PY
       librosa) add_package "librosa" ;;
       accelerate) add_package "accelerate" ;;
       optimum.intel) add_package "optimum-intel[openvino]" ;;
+    esac
+  done
+
+  [[ "${#packages[@]}" -gt 0 ]] || return 0
+  run_cmd "$script_dir" "$python_bin" -m pip install --upgrade "${packages[@]}"
+}
+
+ensure_whisper_asr_helper_python_dependencies() {
+  log "Ensuring Whisper ASR helper Python dependencies..."
+  local probe_output
+  probe_output="$("$python_bin" - <<'PY'
+import importlib.util
+
+def missing(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is None
+    except ModuleNotFoundError:
+        return True
+
+modules = [
+    "openvino",
+    "openvino_genai",
+    "transformers",
+    "librosa",
+    "numpy",
+]
+missing_names = [name for name in modules if missing(name)]
+print("\n".join(missing_names))
+PY
+)"
+
+  mapfile -t missing_modules < <(printf '%s\n' "$probe_output" | sed '/^\s*$/d')
+  if [[ "${#missing_modules[@]}" -eq 0 ]]; then
+    log "Whisper ASR helper Python dependencies already available."
+    return 0
+  fi
+
+  local packages=()
+  local add_package
+  add_package() {
+    local pkg="$1"
+    for existing in "${packages[@]:-}"; do
+      [[ "$existing" == "$pkg" ]] && return 0
+    done
+    packages+=("$pkg")
+  }
+
+  local name
+  for name in "${missing_modules[@]}"; do
+    case "$name" in
+      openvino) add_package "openvino" ;;
+      openvino_genai) add_package "openvino-genai" ;;
+      transformers) add_package "transformers" ;;
+      librosa) add_package "librosa" ;;
+      numpy) add_package "numpy" ;;
     esac
   done
 
@@ -472,6 +531,23 @@ run_npm_cmd() {
   run_cmd "$workdir" "$(command -v npm)" "$@"
 }
 
+verify_node_native_runtimes() {
+  [[ -d "$script_dir/node_modules" ]] || return 1
+  (
+    cd "$script_dir"
+    "$node_bin" --input-type=module - <<'NODE'
+await import('onnxruntime-node');
+await import('@huggingface/transformers');
+NODE
+  ) >/dev/null 2>&1
+}
+
+install_release_runtime_dependencies() {
+  log "Installing release runtime dependencies..."
+  run_npm_cmd "$script_dir" install --omit=dev --no-fund --no-audit --ignore-scripts
+  run_cmd "$script_dir" "$node_bin" scripts/finalize-runtime-install.mjs
+}
+
 ensure_dotenv_file() {
   local env_path="$script_dir/.env"
   if [[ ! -f "$env_path" ]]; then
@@ -511,11 +587,14 @@ export OPENVINO_HELPER_PYTHON="$python_bin"
 ensure_dotenv_file
 env_path="$resolved_env_path"
 dotenv_set "$env_path" "OPENVINO_HELPER_PYTHON" "$python_bin"
-if [[ "$preinstall_local_model_python" -eq 1 ]]; then
+if [[ "$skip_local_model_python" -eq 0 ]]; then
+  ensure_whisper_asr_helper_python_dependencies
+else
+  log "Skipping local ASR helper Python dependency preinstall."
+fi
+if [[ "$preinstall_local_model_python" -eq 1 && "$skip_local_model_python" -eq 0 ]]; then
   ensure_asr_helper_python_dependencies
   ensure_alignment_python_dependencies
-else
-  log "Deferring local-model Python dependency install until helper/conversion use."
 fi
 
 ensure_portable_node
@@ -544,9 +623,11 @@ if [[ "$is_source_workspace" -eq 1 ]]; then
   fi
 else
   if [[ ! -d "$script_dir/node_modules" ]]; then
-    log "Installing release runtime dependencies..."
-    run_npm_cmd "$script_dir" install --omit=dev --no-fund --no-audit --ignore-scripts
-    run_cmd "$script_dir" "$node_bin" scripts/finalize-runtime-install.mjs
+    install_release_runtime_dependencies
+  elif ! verify_node_native_runtimes; then
+    log "Runtime dependencies failed native preload; reinstalling release runtime dependencies..."
+    rm -rf "$script_dir/node_modules" "$script_dir/package-lock.json"
+    install_release_runtime_dependencies
   fi
 fi
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -588,7 +588,11 @@ ensure_dotenv_file
 env_path="$resolved_env_path"
 dotenv_set "$env_path" "OPENVINO_HELPER_PYTHON" "$python_bin"
 if [[ "$skip_local_model_python" -eq 0 ]]; then
-  ensure_whisper_asr_helper_python_dependencies
+  if [[ "$preinstall_local_model_python" -eq 1 ]]; then
+    ensure_whisper_asr_helper_python_dependencies
+  elif ! ensure_whisper_asr_helper_python_dependencies; then
+    log "Whisper ASR helper Python dependency preinstall failed; continuing because local ASR helper setup is optional. Run ./deploy.sh --preinstall-local-model-python to require it."
+  fi
 else
   log "Skipping local ASR helper Python dependency preinstall."
 fi

--- a/scripts/finalize-runtime-install.mjs
+++ b/scripts/finalize-runtime-install.mjs
@@ -67,23 +67,67 @@ async function runNodeScript(scriptRelativePath, args = []) {
   });
 }
 
+async function collectPackageInstallScripts(packageName, candidateScripts) {
+  const scripts = [];
+  const seen = new Set();
+
+  async function addIfPackageDir(packageDir) {
+    for (const candidate of candidateScripts) {
+      const scriptPath = path.join(packageDir, candidate);
+      if (!(await fs.pathExists(scriptPath))) continue;
+      const relativePath = path.relative(root, scriptPath).replace(/\\/g, '/');
+      if (!seen.has(relativePath)) {
+        seen.add(relativePath);
+        scripts.push(relativePath);
+      }
+      return;
+    }
+  }
+
+  async function scanPackageDir(packageDir) {
+    if (path.basename(packageDir) === packageName) {
+      await addIfPackageDir(packageDir);
+    }
+
+    const nestedNodeModules = path.join(packageDir, 'node_modules');
+    if (await fs.pathExists(nestedNodeModules)) {
+      await scanNodeModules(nestedNodeModules);
+    }
+  }
+
+  async function scanNodeModules(nodeModulesDir) {
+    if (!(await fs.pathExists(nodeModulesDir))) return;
+    const entries = await fs.readdir(nodeModulesDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+      const entryPath = path.join(nodeModulesDir, entry.name);
+      if (entry.name.startsWith('@')) {
+        const scopedEntries = await fs.readdir(entryPath, { withFileTypes: true }).catch(() => []);
+        for (const scopedEntry of scopedEntries) {
+          if (!scopedEntry.isDirectory() || scopedEntry.name.startsWith('.')) continue;
+          await scanPackageDir(path.join(entryPath, scopedEntry.name));
+        }
+        continue;
+      }
+
+      await scanPackageDir(entryPath);
+    }
+  }
+
+  await scanNodeModules(path.join(root, 'node_modules'));
+  return scripts;
+}
+
 async function main() {
   log(`Working directory: ${root}`);
 
-  const maybeOnnx = [
-    'node_modules/onnxruntime-node/script/install',
-    'node_modules/onnxruntime-node/script/install.js',
-  ];
-  const onnxInstallScript = [];
-  for (const candidate of maybeOnnx) {
-    if (await pathExists(candidate)) {
-      onnxInstallScript.push(candidate);
-      break;
-    }
-  }
-  if (onnxInstallScript.length > 0) {
-    log('Running onnxruntime-node install script...');
-    await runNodeScript(onnxInstallScript[0]);
+  const onnxInstallScripts = await collectPackageInstallScripts('onnxruntime-node', [
+    'script/install',
+    'script/install.js',
+  ]);
+  for (const script of onnxInstallScripts) {
+    log(`Running onnxruntime-node install script: ${script}`);
+    await runNodeScript(script);
   }
 
   const hasOpenvinoNode = await patchOpenvinoTimeout();

--- a/scripts/install-deployment-assets.mjs
+++ b/scripts/install-deployment-assets.mjs
@@ -65,6 +65,7 @@ function printSummary(snapshot, assetSummary, pyannoteSummary) {
     `[deploy-assets] vad_ready=${snapshot.vad_ready} speaker_embedding_ready=${snapshot.speaker_embedding_ready}`,
     `[deploy-assets] pyannote_ready=${snapshot.pyannote_ready} pyannote_state=${snapshot.pyannote_state}`,
     `[deploy-assets] required_assets_installed=${assetSummary.installed.length} skipped=${assetSummary.skipped.length}`,
+    `[deploy-assets] required_assets_converted=${assetSummary.converted?.length || 0}`,
     `[deploy-assets] pyannote_step=${pyannoteSummary.status}`,
   ];
   for (const line of lines) {

--- a/scripts/package-release.mjs
+++ b/scripts/package-release.mjs
@@ -29,6 +29,15 @@ const runtimeDependencyNames = [
   'unzipper',
 ];
 
+async function readPackageLock() {
+  const lockPath = path.join(root, 'package-lock.json');
+  if (!(await fs.pathExists(lockPath))) {
+    return null;
+  }
+
+  return fs.readJson(lockPath);
+}
+
 const releaseCopies = [
   { source: 'build', destination: 'build' },
   { source: 'dist', destination: 'dist' },
@@ -210,6 +219,7 @@ async function main() {
 
   const packageJsonPath = path.join(root, 'package.json');
   const packageJson = await fs.readJson(packageJsonPath);
+  const packageLock = await readPackageLock();
   const gitHead = spawnSync('git', ['rev-parse', '--short', 'HEAD'], {
     cwd: root,
     encoding: 'utf8',
@@ -227,7 +237,10 @@ async function main() {
   const runtimeDependencies = Object.fromEntries(
     runtimeDependencyNames
       .filter((name) => packageJson.dependencies?.[name])
-      .map((name) => [name, packageJson.dependencies[name]])
+      .map((name) => [
+        name,
+        packageLock?.packages?.[`node_modules/${name}`]?.version || packageJson.dependencies[name],
+      ])
   );
 
   const releasePackageJson = {

--- a/scripts/preflight-linux-runtime.sh
+++ b/scripts/preflight-linux-runtime.sh
@@ -46,6 +46,9 @@ require_file "scripts/finalize-runtime-install.mjs"
 require_file "deploy.sh"
 require_file "start.production.sh"
 require_file "collect-diagnostics.sh"
+require_file "runtime/models/silero_vad.onnx"
+require_file "runtime/models/ecapa-tdnn.xml"
+require_file "runtime/models/ecapa-tdnn.bin"
 require_dir "node_modules"
 
 node_bin="$(resolve_node)"
@@ -73,6 +76,16 @@ for package_dir in \
   "sherpa-onnx"; do
   require_dir "node_modules/$package_dir"
 done
+
+if ! (
+  cd "$script_dir"
+  "$node_bin" --input-type=module - <<'NODE'
+await import('onnxruntime-node');
+await import('@huggingface/transformers');
+NODE
+); then
+  fail "Native ML runtime preload failed. Run ./deploy.sh again to refresh runtime dependencies."
+fi
 
 if [[ ! -f "$script_dir/.env" ]]; then
   warn ".env is not present yet. Run ./deploy.sh to create it and generate ENCRYPTION_KEY."

--- a/server/http/routes/local_model_routes.ts
+++ b/server/http/routes/local_model_routes.ts
@@ -102,6 +102,17 @@ export function registerSystemAndLocalModelRoutes(app: express.Express) {
     }
   });
 
+  app.post('/api/runtime/pyannote/clear-error', async (req, res) => {
+    try {
+      const status = await PyannoteSetupService.clearError();
+      return res.json({ success: true, status });
+    } catch (error: any) {
+      return res.status(500).json({
+        error: error?.message || 'Failed to clear pyannote error.',
+      });
+    }
+  });
+
   app.get('/api/local-models', async (req, res) => {
     try {
       const LocalModelService = await getLocalModelService();
@@ -223,6 +234,17 @@ export function registerSystemAndLocalModelRoutes(app: express.Express) {
       return res.json(data);
     } catch (error: any) {
       return res.status(400).json({ error: error?.message || 'Failed to remove local model.' });
+    }
+  });
+
+  app.post('/api/local-models/install-status/clear', async (req, res) => {
+    try {
+      const LocalModelService = await getLocalModelService();
+      const modelId = typeof req.body?.modelId === 'string' ? req.body.modelId.trim() : '';
+      const data = await LocalModelService.clearInstallErrors({ modelId });
+      return res.json(data);
+    } catch (error: any) {
+      return res.status(400).json({ error: error?.message || 'Failed to clear local model install status.' });
     }
   });
 

--- a/server/openvino_backend.ts
+++ b/server/openvino_backend.ts
@@ -173,6 +173,15 @@ export class OpenvinoBackend {
     return core.compileModel(modelPath, device, config);
   }
 
+  static async convertModelToIr(sourcePath: string, outputXmlPath: string, options: { compressToFp16?: boolean } = {}) {
+    const core = await this.getCore();
+    const ov = await this.getAddon();
+    const outputDir = path.dirname(outputXmlPath);
+    await fs.ensureDir(outputDir);
+    const model = await core.readModel(sourcePath);
+    ov.saveModelSync(model, outputXmlPath, options.compressToFp16 ?? false);
+  }
+
   static async createTensor(type: string, shape: number[], data: any) {
     const ov = await this.getAddon();
     return new ov.Tensor(type, shape, data);

--- a/server/pyannote_diarization_service.ts
+++ b/server/pyannote_diarization_service.ts
@@ -200,6 +200,32 @@ export class PyannoteDiarizationService {
     });
   }
 
+  private static async ensurePythonPackagingTools() {
+    const probe = [
+      'import importlib.util',
+      'missing = [name for name in ("setuptools", "wheel") if importlib.util.find_spec(name) is None]',
+      'print("\\n".join(missing))',
+    ].join('\n');
+
+    const probeResult = await this.runPythonChecked(
+      ['-c', probe],
+      'Failed to inspect Python packaging tools.'
+    );
+    const missing = String(probeResult.stdout || '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    if (missing.length === 0) {
+      return;
+    }
+
+    await this.runPythonChecked(
+      ['-m', 'pip', 'install', '--upgrade', 'pip', 'setuptools', 'wheel'],
+      'Failed to install Python packaging tools required for pyannote dependencies.'
+    );
+  }
+
   private static async ensurePythonDependencies() {
     if (this.pythonDepsPromise) {
       return this.pythonDepsPromise;
@@ -257,8 +283,9 @@ export class PyannoteDiarizationService {
         return;
       }
 
+      await this.ensurePythonPackagingTools();
       await this.runPythonChecked(
-        ['-m', 'pip', 'install', '--upgrade', ...packages],
+        ['-m', 'pip', 'install', '--upgrade', '--no-build-isolation', ...packages],
         'Failed to install pyannote Python dependencies.'
       );
     })();

--- a/server/services/local_model_service.ts
+++ b/server/services/local_model_service.ts
@@ -128,6 +128,14 @@ export class LocalModelService {
       .sort((a, b) => b.updatedAt - a.updatedAt);
   }
 
+  private static clearInstallErrorState(modelId: string) {
+    this.installErrors.delete(modelId);
+    const state = this.installStates.get(modelId);
+    if (state?.phase === 'failed' && !state.installing) {
+      this.installStates.delete(modelId);
+    }
+  }
+
   private static getArtifactInstallPhase(model: LocalModelDefinition): LocalModelInstallPhase {
     return model.installMode === 'hf-direct' ? 'downloading' : 'converting';
   }
@@ -1338,6 +1346,24 @@ export class LocalModelService {
     const nextInstalled = registered.filter((item) => item.id !== modelId);
     await this.persistInstalledModels(settings, nextInstalled);
 
+    this.invalidateOverviewCache();
+    return this.getLocalModelsOverview({ forceFresh: true });
+  }
+
+  static async clearInstallErrors(input?: { modelId?: string | null }) {
+    const modelId = String(input?.modelId || '').trim();
+    if (modelId) {
+      this.clearInstallErrorState(modelId);
+    } else {
+      for (const id of Array.from(this.installErrors.keys())) {
+        this.clearInstallErrorState(id);
+      }
+      for (const [id, state] of Array.from(this.installStates.entries())) {
+        if (state.phase === 'failed' && !state.installing) {
+          this.installStates.delete(id);
+        }
+      }
+    }
     this.invalidateOverviewCache();
     return this.getLocalModelsOverview({ forceFresh: true });
   }

--- a/server/services/pyannote_setup_service.ts
+++ b/server/services/pyannote_setup_service.ts
@@ -65,6 +65,11 @@ export class PyannoteSetupService {
     return this.getStatus();
   }
 
+  static async clearError() {
+    this.lastError = null;
+    return this.getStatus();
+  }
+
   static async ensureInstalled(input?: { token?: string }) {
     const token = String(input?.token || '').trim();
     if (token) {

--- a/server/services/resource_manager.ts
+++ b/server/services/resource_manager.ts
@@ -5,6 +5,7 @@ import https from 'https';
 import unzipper from 'unzipper';
 import { pipeline } from 'stream/promises';
 import { getBundledToolPath, isCommandAvailable } from '../runtime_tools.js';
+import { OpenvinoBackend } from '../openvino_backend.js';
 
 interface BaselineAssetDefinition {
   id: string;
@@ -17,8 +18,10 @@ export interface BaselineAssetEnsureResult {
   id: string;
   category: string;
   path: string;
+  irPath?: string;
   sourceUrl: string;
   installed: boolean;
+  converted: boolean;
   skipped: boolean;
   ready: boolean;
 }
@@ -109,17 +112,61 @@ export class ResourceManager {
     return asset;
   }
 
+  private static getBaselineIrPath(asset: BaselineAssetDefinition, sourcePath: string) {
+    if (asset.category !== 'speaker_embedding') {
+      return null;
+    }
+    if (!sourcePath.toLowerCase().endsWith('.onnx')) {
+      return null;
+    }
+    return sourcePath.replace(/\.onnx$/i, '.xml');
+  }
+
+  private static async ensureBaselineIrAsset(asset: BaselineAssetDefinition, sourcePath: string) {
+    const irPath = this.getBaselineIrPath(asset, sourcePath);
+    if (!irPath) {
+      return { irPath: undefined, converted: false };
+    }
+
+    const binPath = irPath.replace(/\.xml$/i, '.bin');
+    const [hasXml, hasBin] = await Promise.all([
+      fs.pathExists(irPath),
+      fs.pathExists(binPath),
+    ]);
+    if (hasXml && hasBin) {
+      return { irPath, converted: false };
+    }
+
+    console.log(`[ResourceManager] Converting baseline asset ${asset.id} to OpenVINO IR -> ${irPath}`);
+    await fs.remove(irPath).catch(() => {});
+    await fs.remove(binPath).catch(() => {});
+    await OpenvinoBackend.convertModelToIr(sourcePath, irPath, { compressToFp16: false });
+
+    const [convertedXml, convertedBin] = await Promise.all([
+      fs.pathExists(irPath),
+      fs.pathExists(binPath),
+    ]);
+    if (!convertedXml || !convertedBin) {
+      throw new Error(`OpenVINO IR conversion did not produce expected files for ${asset.id}.`);
+    }
+
+    return { irPath, converted: true };
+  }
+
   static async ensureBaselineAsset(identifier: string, manifestOverride?: any): Promise<BaselineAssetEnsureResult> {
     const asset = await this.getRequiredBaselineAsset(identifier, manifestOverride);
     const destination = path.join(PathManager.getModelsPath(), asset.targetRelativePath);
 
     if (await fs.pathExists(destination)) {
+      const irResult = await this.ensureBaselineIrAsset(asset, destination);
       return {
         id: asset.id,
         category: asset.category,
         path: destination,
+        irPath: irResult.irPath,
         sourceUrl: asset.sourceUrl,
         installed: false,
+        converted: irResult.converted,
         skipped: true,
         ready: true,
       };
@@ -132,12 +179,15 @@ export class ResourceManager {
     const task = (async () => {
       console.log(`[ResourceManager] Downloading baseline asset ${asset.id} -> ${destination}`);
       await this.downloadWithRedirect(asset.sourceUrl, destination);
+      const irResult = await this.ensureBaselineIrAsset(asset, destination);
       return {
         id: asset.id,
         category: asset.category,
         path: destination,
+        irPath: irResult.irPath,
         sourceUrl: asset.sourceUrl,
         installed: true,
+        converted: irResult.converted,
         skipped: false,
         ready: true,
       };
@@ -156,10 +206,14 @@ export class ResourceManager {
 
   static async ensureRequiredBaselineAssets(manifestOverride?: any) {
     const installed: Array<{ id: string; path: string }> = [];
+    const converted: Array<{ id: string; path: string }> = [];
     const skipped: Array<{ id: string; path: string }> = [];
 
     for (const asset of await this.getRequiredBaselineAssets(manifestOverride)) {
       const result = await this.ensureBaselineAsset(asset.id, manifestOverride);
+      if (result.converted && result.irPath) {
+        converted.push({ id: result.id, path: result.irPath });
+      }
       if (result.installed) {
         installed.push({ id: result.id, path: result.path });
       } else {
@@ -167,7 +221,7 @@ export class ResourceManager {
       }
     }
 
-    return { installed, skipped };
+    return { installed, converted, skipped };
   }
 
   static async ensureTools() {

--- a/server/services/runtime_readiness_service.ts
+++ b/server/services/runtime_readiness_service.ts
@@ -150,6 +150,16 @@ async function getFileReadiness(targetPath: string): Promise<FileReadiness> {
   };
 }
 
+async function getPreferredFileReadiness(targetPaths: string[]): Promise<FileReadiness> {
+  let fallback: FileReadiness | null = null;
+  for (const targetPath of targetPaths) {
+    const readiness = await getFileReadiness(targetPath);
+    if (!fallback) fallback = readiness;
+    if (readiness.exists) return readiness;
+  }
+  return fallback ?? { path: targetPaths[0] ?? '', exists: false };
+}
+
 async function hasConfiguredEnvValue(filePath: string, key: string) {
   if (!(await fs.pathExists(filePath))) return false;
   const content = await fs.readFile(filePath, 'utf8');
@@ -323,9 +333,12 @@ export class RuntimeReadinessService {
     const python = getPythonReadiness();
     const ffmpeg = getToolReadiness('ffmpeg');
     const ytDlp = getToolReadiness('yt-dlp');
-    const vad = await getFileReadiness(path.join(PathManager.getModelsPath(), 'silero_vad.onnx'));
+    const vad = await getPreferredFileReadiness([
+      path.join(PathManager.getModelsPath(), 'silero_vad.xml'),
+      path.join(PathManager.getModelsPath(), 'silero_vad.onnx'),
+    ]);
     const tenVad = await getFileReadiness(path.join(PathManager.getModelsPath(), 'ten-vad.onnx'));
-    const speakerEmbedding = await getFileReadiness(path.join(PathManager.getModelsPath(), 'ecapa-tdnn.onnx'));
+    const speakerEmbedding = await getFileReadiness(path.join(PathManager.getModelsPath(), 'ecapa-tdnn.xml'));
     const pyannoteSegmentation = await getFileReadiness(path.join(PathManager.getModelsPath(), 'pyannote', 'segmentation', 'model.xml'));
     const pyannoteEmbedding = await getFileReadiness(path.join(PathManager.getModelsPath(), 'pyannote', 'embedding', 'model.xml'));
     const pyannotePlda = await getFileReadiness(path.join(PathManager.getModelsPath(), 'pyannote', 'plda', 'vbx.json'));

--- a/server/services/runtime_readiness_service.ts
+++ b/server/services/runtime_readiness_service.ts
@@ -338,7 +338,10 @@ export class RuntimeReadinessService {
       path.join(PathManager.getModelsPath(), 'silero_vad.onnx'),
     ]);
     const tenVad = await getFileReadiness(path.join(PathManager.getModelsPath(), 'ten-vad.onnx'));
-    const speakerEmbedding = await getFileReadiness(path.join(PathManager.getModelsPath(), 'ecapa-tdnn.xml'));
+    const speakerEmbedding = await getPreferredFileReadiness([
+      path.join(PathManager.getModelsPath(), 'ecapa-tdnn.xml'),
+      path.join(PathManager.getModelsPath(), 'ecapa-tdnn.onnx'),
+    ]);
     const pyannoteSegmentation = await getFileReadiness(path.join(PathManager.getModelsPath(), 'pyannote', 'segmentation', 'model.xml'));
     const pyannoteEmbedding = await getFileReadiness(path.join(PathManager.getModelsPath(), 'pyannote', 'embedding', 'model.xml'));
     const pyannotePlda = await getFileReadiness(path.join(PathManager.getModelsPath(), 'pyannote', 'plda', 'vbx.json'));

--- a/server/services/runtime_readiness_service.ts
+++ b/server/services/runtime_readiness_service.ts
@@ -150,14 +150,24 @@ async function getFileReadiness(targetPath: string): Promise<FileReadiness> {
   };
 }
 
-async function getPreferredFileReadiness(targetPaths: string[]): Promise<FileReadiness> {
-  let fallback: FileReadiness | null = null;
-  for (const targetPath of targetPaths) {
-    const readiness = await getFileReadiness(targetPath);
-    if (!fallback) fallback = readiness;
-    if (readiness.exists) return readiness;
-  }
-  return fallback ?? { path: targetPaths[0] ?? '', exists: false };
+async function getOpenvinoIrReadiness(xmlPath: string): Promise<FileReadiness> {
+  const binPath = xmlPath.replace(/\.xml$/i, '.bin');
+  const [hasXml, hasBin] = await Promise.all([
+    fs.pathExists(xmlPath),
+    fs.pathExists(binPath),
+  ]);
+  return {
+    path: xmlPath,
+    exists: hasXml && hasBin,
+  };
+}
+
+async function getPreferredBaselineModelReadiness(paths: { irXmlPath: string; onnxPath: string }): Promise<FileReadiness> {
+  const ir = await getOpenvinoIrReadiness(paths.irXmlPath);
+  if (ir.exists) return ir;
+  const onnx = await getFileReadiness(paths.onnxPath);
+  if (onnx.exists) return onnx;
+  return ir;
 }
 
 async function hasConfiguredEnvValue(filePath: string, key: string) {
@@ -333,15 +343,15 @@ export class RuntimeReadinessService {
     const python = getPythonReadiness();
     const ffmpeg = getToolReadiness('ffmpeg');
     const ytDlp = getToolReadiness('yt-dlp');
-    const vad = await getPreferredFileReadiness([
-      path.join(PathManager.getModelsPath(), 'silero_vad.xml'),
-      path.join(PathManager.getModelsPath(), 'silero_vad.onnx'),
-    ]);
+    const vad = await getPreferredBaselineModelReadiness({
+      irXmlPath: path.join(PathManager.getModelsPath(), 'silero_vad.xml'),
+      onnxPath: path.join(PathManager.getModelsPath(), 'silero_vad.onnx'),
+    });
     const tenVad = await getFileReadiness(path.join(PathManager.getModelsPath(), 'ten-vad.onnx'));
-    const speakerEmbedding = await getPreferredFileReadiness([
-      path.join(PathManager.getModelsPath(), 'ecapa-tdnn.xml'),
-      path.join(PathManager.getModelsPath(), 'ecapa-tdnn.onnx'),
-    ]);
+    const speakerEmbedding = await getPreferredBaselineModelReadiness({
+      irXmlPath: path.join(PathManager.getModelsPath(), 'ecapa-tdnn.xml'),
+      onnxPath: path.join(PathManager.getModelsPath(), 'ecapa-tdnn.onnx'),
+    });
     const pyannoteSegmentation = await getFileReadiness(path.join(PathManager.getModelsPath(), 'pyannote', 'segmentation', 'model.xml'));
     const pyannoteEmbedding = await getFileReadiness(path.join(PathManager.getModelsPath(), 'pyannote', 'embedding', 'model.xml'));
     const pyannotePlda = await getFileReadiness(path.join(PathManager.getModelsPath(), 'pyannote', 'plda', 'vbx.json'));

--- a/server/speaker_embedding_service.ts
+++ b/server/speaker_embedding_service.ts
@@ -9,13 +9,22 @@ export class SpeakerEmbeddingService {
   private static compiledModel: any | null = null;
   private static inputName: string | null = null;
   private static modelPath = path.join(PathManager.getModelsPath(), "ecapa-tdnn.onnx");
+  private static irModelPath = path.join(PathManager.getModelsPath(), "ecapa-tdnn.xml");
+
+  private static async getPreferredModelPath() {
+    if (await fs.pathExists(this.irModelPath)) {
+      return this.irModelPath;
+    }
+    return this.modelPath;
+  }
 
   /**
    * Initializes the OpenVINO compiled model on AUTO device selection.
    */
   static async init() {
     if (this.compiledModel) return;
-    if (!(await fs.pathExists(this.modelPath))) {
+    const hasAnyModel = (await fs.pathExists(this.irModelPath)) || (await fs.pathExists(this.modelPath));
+    if (!hasAnyModel) {
       try {
         await ResourceManager.ensureBaselineAsset("speaker_embedding");
       } catch (error) {
@@ -24,13 +33,14 @@ export class SpeakerEmbeddingService {
       }
     }
 
-    if (!(await fs.pathExists(this.modelPath))) {
-      throw new Error(`[Embedding] model not found: ${this.modelPath}`);
+    const modelPath = await this.getPreferredModelPath();
+    if (!(await fs.pathExists(modelPath))) {
+      throw new Error(`[Embedding] model not found: ${this.irModelPath} or ${this.modelPath}`);
     }
 
     const device = OpenvinoBackend.getBaselineModelDevice();
-    console.log(`[Embedding] Compiling model with OpenVINO device: ${device}`);
-    this.compiledModel = await OpenvinoBackend.compileModel(this.modelPath, device);
+    console.log(`[Embedding] Compiling model with OpenVINO device: ${device} (${path.basename(modelPath)})`);
+    this.compiledModel = await OpenvinoBackend.compileModel(modelPath, device);
     this.inputName = OpenvinoBackend.getPortName(this.compiledModel.input(0), "input");
     console.log("[Embedding] OpenVINO model ready");
   }

--- a/server/speaker_embedding_service.ts
+++ b/server/speaker_embedding_service.ts
@@ -11,8 +11,20 @@ export class SpeakerEmbeddingService {
   private static modelPath = path.join(PathManager.getModelsPath(), "ecapa-tdnn.onnx");
   private static irModelPath = path.join(PathManager.getModelsPath(), "ecapa-tdnn.xml");
 
+  private static get irWeightsPath() {
+    return this.irModelPath.replace(/\.xml$/i, ".bin");
+  }
+
+  private static async hasIrModelPair() {
+    const [hasXml, hasBin] = await Promise.all([
+      fs.pathExists(this.irModelPath),
+      fs.pathExists(this.irWeightsPath),
+    ]);
+    return hasXml && hasBin;
+  }
+
   private static async getPreferredModelPath() {
-    if (await fs.pathExists(this.irModelPath)) {
+    if (await this.hasIrModelPair()) {
       return this.irModelPath;
     }
     return this.modelPath;
@@ -23,7 +35,7 @@ export class SpeakerEmbeddingService {
    */
   static async init() {
     if (this.compiledModel) return;
-    const hasAnyModel = (await fs.pathExists(this.irModelPath)) || (await fs.pathExists(this.modelPath));
+    const hasAnyModel = (await this.hasIrModelPair()) || (await fs.pathExists(this.modelPath));
     if (!hasAnyModel) {
       try {
         await ResourceManager.ensureBaselineAsset("speaker_embedding");

--- a/server/vad_service.ts
+++ b/server/vad_service.ts
@@ -14,6 +14,7 @@ export interface SpeechSegment {
 }
 
 type VadEngine = "silero" | "ten" | "auto" | "compare";
+type OnnxRuntimeVadProvider = "cpu" | "dml" | "webgpu";
 
 const require = createRequire(import.meta.url);
 
@@ -74,6 +75,46 @@ export class VadService {
     const raw = String(process.env.VAD_ENGINE ?? "silero").trim().toLowerCase();
     if (raw === "ten" || raw === "auto" || raw === "compare") return raw;
     return "silero";
+  }
+
+  private static normalizeOnnxRuntimeProvider(raw: string): OnnxRuntimeVadProvider | null {
+    const value = raw.trim().toLowerCase();
+    if (!value) return null;
+    if (value === "cpu" || value === "cpuexecutionprovider") return "cpu";
+    if (value === "dml" || value === "directml" || value === "directmlexecutionprovider") return "dml";
+    if (value === "webgpu" || value === "webgpuexecutionprovider") return "webgpu";
+    return null;
+  }
+
+  private static getOnnxRuntimeProviderLabel(provider: OnnxRuntimeVadProvider) {
+    return provider === "dml" ? "directml" : provider;
+  }
+
+  private static getOnnxRuntimeProviders(): OnnxRuntimeVadProvider[] {
+    const raw = String(process.env.VAD_ONNXRUNTIME_PROVIDERS ?? "").trim();
+    if (!raw) return ["cpu"];
+
+    const providers: OnnxRuntimeVadProvider[] = [];
+    const seen = new Set<OnnxRuntimeVadProvider>();
+    for (const part of raw.split(/[,\s;]+/)) {
+      const provider = this.normalizeOnnxRuntimeProvider(part);
+      if (!provider) {
+        if (part.trim()) {
+          console.warn(`[VAD] Ignoring unsupported VAD_ONNXRUNTIME_PROVIDERS entry: ${part}`);
+        }
+        continue;
+      }
+      if (seen.has(provider)) continue;
+      seen.add(provider);
+      providers.push(provider);
+    }
+
+    if (providers.length === 0) {
+      console.warn("[VAD] VAD_ONNXRUNTIME_PROVIDERS has no valid providers, falling back to cpu.");
+      return ["cpu"];
+    }
+
+    return providers;
   }
 
   private static getFfmpegBinary() {
@@ -508,10 +549,13 @@ export class VadService {
       console.log("[VAD] No OpenVINO-compatible VAD IR model found, using ONNX Runtime fallback.");
     }
 
-    const providers = process.platform === "win32" ? ["dml", "webgpu", "cpu"] : ["webgpu", "cpu"];
+    const providers = this.getOnnxRuntimeProviders();
+    console.log(
+      `[VAD] ONNX Runtime provider order: ${providers.map((provider) => this.getOnnxRuntimeProviderLabel(provider)).join(", ")}`
+    );
     for (const provider of providers) {
       try {
-        const label = provider === "dml" ? "directml" : provider;
+        const label = this.getOnnxRuntimeProviderLabel(provider);
         console.log(`[VAD] Trying ONNX Runtime execution provider: ${label}`);
         this.session = await ort.InferenceSession.create(this.modelPath, {
           executionProviders: [provider],
@@ -520,7 +564,7 @@ export class VadService {
         console.log(`[VAD] Using inference backend: ONNX Runtime (${label})`);
         return;
       } catch {
-        const label = provider === "dml" ? "directml" : provider;
+        const label = this.getOnnxRuntimeProviderLabel(provider);
         console.warn(`[VAD] Provider ${label} unavailable, trying next...`);
       }
     }

--- a/server/vad_service.ts
+++ b/server/vad_service.ts
@@ -153,7 +153,12 @@ export class VadService {
     }
 
     const xmlCandidate = this.modelPath.replace(/\.onnx$/i, ".xml");
-    if (xmlCandidate !== this.modelPath && (await fs.pathExists(xmlCandidate))) {
+    const binCandidate = xmlCandidate.replace(/\.xml$/i, ".bin");
+    const [hasXml, hasBin] = await Promise.all([
+      fs.pathExists(xmlCandidate),
+      fs.pathExists(binCandidate),
+    ]);
+    if (xmlCandidate !== this.modelPath && hasXml && hasBin) {
       return xmlCandidate;
     }
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1435,6 +1435,22 @@ export default function Settings({ project }: { project: Project | null }) {
     }
   };
 
+  const handleClearLocalInstallStatus = async (modelId: string) => {
+    setLocalErrorScope(null);
+    setLocalError(null);
+    try {
+      const data = await postJson<LocalModelsResponse>(
+        '/api/local-models/install-status/clear',
+        { modelId },
+        { timeoutMs: 30_000, retries: 0 }
+      );
+      applyLocalModelsResponse(data);
+    } catch (error: any) {
+      setLocalErrorScope('install');
+      setLocalError(formatRequestError(error, t('settings.localInstallFailed')));
+    }
+  };
+
   const handleSavePyannoteToken = async () => {
     const token = pyannoteTokenInput.trim();
     if (!token) {
@@ -1480,6 +1496,23 @@ export default function Settings({ project }: { project: Project | null }) {
       setPyannoteMessage(String(error?.message || pyannoteCopy.installFailed));
     } finally {
       setPyannoteBusy(false);
+    }
+  };
+
+  const handleClearPyannoteError = async () => {
+    setPyannoteMessageScope(null);
+    setPyannoteMessage(null);
+    try {
+      const data = await postJson<{ success?: boolean; status?: PyannoteStatus }>(
+        '/api/runtime/pyannote/clear-error',
+        {},
+        { timeoutMs: 30_000, retries: 0 }
+      );
+      setPyannoteStatus(data.status || null);
+      await loadLocalModels();
+    } catch (error: any) {
+      setPyannoteMessageScope('install');
+      setPyannoteMessage(String(error?.message || pyannoteCopy.installFailed));
     }
   };
 
@@ -1845,7 +1878,18 @@ export default function Settings({ project }: { project: Project | null }) {
                   </span>
                 </div>
                 {pyannoteStatus?.lastError && !pyannoteStatus.ready && (
-                  <div className="mt-2 break-all text-[11px] text-error/80">{pyannoteStatus.lastError}</div>
+                  <div className="mt-2 flex items-start gap-2 rounded-lg border border-error/15 bg-error/5 px-3 py-2 text-[11px] text-error/80">
+                    <div className="min-w-0 flex-1 break-all">{pyannoteStatus.lastError}</div>
+                    <button
+                      type="button"
+                      onClick={() => void handleClearPyannoteError()}
+                      className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-error/20 text-error/70 transition-colors hover:bg-error/10 hover:text-error"
+                      aria-label={t('dashboard.close')}
+                      title={t('dashboard.close')}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
                 )}
               </div>
               <button
@@ -2006,11 +2050,24 @@ export default function Settings({ project }: { project: Project | null }) {
                           </div>
                           <div className="mt-1 break-all text-outline">{status.repoId}</div>
                         </div>
-                        <div className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-bold ${
-                          failed ? 'bg-error/10 text-error' : 'bg-primary-container/10 text-primary'
-                        }`}>
-                          {status.installing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : failed ? <AlertCircle className="h-3.5 w-3.5" /> : null}
-                          {formatLocalInstallPhase(localCopy, status.phase)}
+                        <div className="flex items-center gap-2">
+                          <div className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-bold ${
+                            failed ? 'bg-error/10 text-error' : 'bg-primary-container/10 text-primary'
+                          }`}>
+                            {status.installing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : failed ? <AlertCircle className="h-3.5 w-3.5" /> : null}
+                            {formatLocalInstallPhase(localCopy, status.phase)}
+                          </div>
+                          {failed && (
+                            <button
+                              type="button"
+                              onClick={() => void handleClearLocalInstallStatus(status.modelId)}
+                              className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-error/20 text-error/70 transition-colors hover:bg-error/10 hover:text-error"
+                              aria-label={t('dashboard.close')}
+                              title={t('dashboard.close')}
+                            >
+                              <X className="h-3.5 w-3.5" />
+                            </button>
+                          )}
                         </div>
                       </div>
                       {status.error && (
@@ -2107,8 +2164,17 @@ export default function Settings({ project }: { project: Project | null }) {
                       </button>
                     </div>
                     {model.installError && (
-                      <div className="rounded-lg border border-error/20 bg-error/10 px-3 py-2 text-[11px] text-error">
-                        {model.installError}
+                      <div className="flex items-start gap-2 rounded-lg border border-error/20 bg-error/10 px-3 py-2 text-[11px] text-error">
+                        <div className="min-w-0 flex-1 break-all">{model.installError}</div>
+                        <button
+                          type="button"
+                          onClick={() => void handleClearLocalInstallStatus(model.id)}
+                          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-error/20 text-error/70 transition-colors hover:bg-error/10 hover:text-error"
+                          aria-label={t('dashboard.close')}
+                          title={t('dashboard.close')}
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
                       </div>
                     )}
                   </div>
@@ -2196,8 +2262,17 @@ export default function Settings({ project }: { project: Project | null }) {
                       </button>
                     </div>
                     {model.installError && (
-                      <div className="rounded-lg border border-error/20 bg-error/10 px-3 py-2 text-[11px] text-error">
-                        {model.installError}
+                      <div className="flex items-start gap-2 rounded-lg border border-error/20 bg-error/10 px-3 py-2 text-[11px] text-error">
+                        <div className="min-w-0 flex-1 break-all">{model.installError}</div>
+                        <button
+                          type="button"
+                          onClick={() => void handleClearLocalInstallStatus(model.id)}
+                          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-error/20 text-error/70 transition-colors hover:bg-error/10 hover:text-error"
+                          aria-label={t('dashboard.close')}
+                          title={t('dashboard.close')}
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
                       </div>
                     )}
                   </div>

--- a/src/components/SpeechToText.tsx
+++ b/src/components/SpeechToText.tsx
@@ -773,6 +773,19 @@ export default function SpeechToText({ project, onUpdateProject, onNext, onBack,
     [loadPyannoteStatus, pyannoteSetupCopy.installIncomplete]
   );
 
+  const clearPyannoteError = React.useCallback(async () => {
+    try {
+      const response = await postJson<{ success?: boolean; status?: PyannoteSetupStatus }>(
+        '/api/runtime/pyannote/clear-error',
+        {},
+        { timeoutMs: 30_000, retries: 0 }
+      );
+      setPyannoteStatus(response?.status || (await loadPyannoteStatus()));
+    } catch (error) {
+      console.error('Failed to clear pyannote error', error);
+    }
+  }, [loadPyannoteStatus]);
+
   const ensurePyannoteProviderReady = React.useCallback(async () => {
     let tokenConfigured = Boolean(pyannoteStatus?.tokenConfigured);
 
@@ -2315,8 +2328,17 @@ export default function SpeechToText({ project, onUpdateProject, onNext, onBack,
                             </div>
                           )}
                           {pyannoteStatus?.lastError && !pyannoteStatus.ready && (
-                            <div className="mt-2 text-[11px] leading-relaxed text-error/80">
-                              {pyannoteStatus.lastError}
+                            <div className="mt-2 flex items-start gap-2 rounded-lg border border-error/15 bg-error/5 px-3 py-2 text-[11px] leading-relaxed text-error/80">
+                              <div className="min-w-0 flex-1 break-all">{pyannoteStatus.lastError}</div>
+                              <button
+                                type="button"
+                                onClick={() => void clearPyannoteError()}
+                                className="mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-error/20 text-error/70 transition-colors hover:bg-error/10 hover:text-error"
+                                aria-label={t('dashboard.close')}
+                                title={t('dashboard.close')}
+                              >
+                                <X className="h-3 w-3" />
+                              </button>
                             </div>
                           )}
                         </div>


### PR DESCRIPTION
## Summary

This PR fixes the release/runtime setup issues found during v0.9.2 Windows and Linux package validation.

- pins release runtime dependencies from `package-lock.json` so packaged installs do not drift to incompatible native package versions
- finalizes all nested `onnxruntime-node` installs instead of only the top-level package
- preinstalls the Whisper ASR helper Python dependencies during deploy so first local ASR runs do not time out while installing `librosa`
- keeps VAD on stable ONNX Runtime CPU fallback by default, with configurable provider order
- converts the ECAPA speaker embedding baseline ONNX model to OpenVINO IR during deployment and prefers the IR model at runtime
- improves runtime readiness/preflight checks for packaged Windows and Linux releases
- adds clearable install error state for local model and Pyannote setup failures in the UI/API

## Root Cause

Clean release environments exposed three packaging/runtime gaps:

- npm semver ranges allowed native dependency versions to drift after deploy, which could mismatch ONNX Runtime bindings and shared libraries.
- local ASR helper dependencies were installed lazily during the first transcription request, so a clean Windows VM could hit the helper load timeout while `pip` was still installing packages.
- speaker embedding used an ONNX baseline even though it can be reliably preconverted to OpenVINO IR; Silero VAD cannot be safely forced through the current OpenVINO converter, so it remains on the stable ONNX path unless an IR file is explicitly present.

## Validation

- `npx tsc -p tsconfig.server.json --noEmit`
- `npx tsc --noEmit`
- `npm run -s build:prod`
- Windows release package rebuilt and archived
- Linux release package rebuilt and archived
- Windows release dry run passed
- Linux release preflight passed
- packaged native imports checked for `onnxruntime-node` and `openvino-node`
- packaged ECAPA IR compile checked on CPU
- packaged Silero ONNX Runtime CPU session checked

## Notes

The generated release archives remain ignored and are not included in this PR. After merging, rebuild the official Windows/Linux release archives from the merge commit so `release-manifest.json` points at the final source revision.