### PR TITLE
Update contribution guidelines for documentation PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,13 +5,19 @@
 
 ## Verification
 
-- [ ] `npm run -s check`
-- [ ] manual verification for the changed workflow
+- [ ] `npm run -s check` if code changes are included
+- [ ] docs-only/manual review if this only changes documentation
+- [ ] manual verification for the changed workflow, if applicable
 
 ## Privacy Review
 
 - [ ] no secrets, tokens, or private local data are included
 - [ ] no `runtime/` snapshot, `.env` content, or personal media is included
+
+## Contributor Notes
+
+- PRs should normally be opened from a feature branch, not from `main`
+- documentation translations should update related language lists when needed
 
 ## Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,17 @@ Public guides:
 
 ## Before opening a pull request
 
+Please open pull requests from a feature branch, not from `main`.
+
+Good branch names are short and describe the change:
+
+- `docs/add-german-readme`
+- `docs/improve-installation-guide`
+- `ui/clarify-empty-states`
+
+Keep each pull request focused on one purpose. Smaller pull requests are easier
+to review, test, and merge.
+
 For source-repo work, use the normal dev startup helpers:
 
 ```powershell
@@ -20,13 +31,17 @@ npm install
 ./start.sh
 ```
 
-Before opening a pull request, please run:
+For code changes, please run:
 
 ```powershell
 npm run -s check
 ```
 
-If your change affects startup, runtime preparation, or deployment behavior, it is also helpful to check:
+For documentation-only changes, a manual review of the changed links and text is
+usually enough.
+
+If your change affects startup, runtime preparation, or deployment behavior, it
+is also helpful to check:
 
 ```powershell
 npm run clean:runtime:dry
@@ -39,6 +54,24 @@ npm run clean:runtime:dry
 - keep user-facing wording polite, clear, and consistent across languages
 - keep release-facing docs and source-repo docs aligned
 - verify changes before submitting
+
+## Documentation and translation contributions
+
+Documentation and translation contributions are welcome. Please keep them
+user-facing and avoid internal implementation details that normal users do not
+need.
+
+When adding a new translated README:
+
+- add the new `README.<locale>.md` file
+- add the new language link to the existing root README files
+- keep the same public structure as the existing README files where practical
+- link download instructions to the latest GitHub Release instead of a fixed
+  version number
+- if localized docs such as `docs/<locale>/` do not exist yet, link to the
+  existing English docs for now
+- do not include private paths, local runtime snapshots, API keys, tokens,
+  personal media, or `.env` content
 
 ## Security issues
 


### PR DESCRIPTION
## Summary

- clarify that PRs should be opened from feature branches instead of `main`
- document expectations for translated README contributions
- make the PR template friendlier for docs-only changes

## Verification

- [x] docs-only/manual review
- [x] `git diff --check -- CONTRIBUTING.md .github/PULL_REQUEST_TEMPLATE.md`

## Privacy Review

- [x] no secrets, tokens, or private local data are included
- [x] no `runtime/` snapshot, `.env` content, or personal media is included